### PR TITLE
Feature/18 add invitation acceptance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,11 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(resource)
-    stored_location_for(resource) || dashboard_path
+    if session[:invitation_token].present?
+      invitation_path(session[:invitation_token])
+    else
+      stored_location_for(resource) || dashboard_path
+    end
   end
 
   def after_sign_out_path_for(_resource_or_scope)

--- a/app/controllers/group_memberships_controller.rb
+++ b/app/controllers/group_memberships_controller.rb
@@ -12,13 +12,13 @@ class GroupMembershipsController < ApplicationController
     end
 
     ActiveRecord::Base.transaction do
-      #GroupMembershipを作成して参加
+      # GroupMembershipを作成して参加
       GroupMembership.create!(
         user: current_user,
         group: group
       )
 
-      #招待の更新
+      # 招待の更新
       @invitation.update!(
         status: :accepted,
         used_by: current_user,
@@ -26,7 +26,7 @@ class GroupMembershipsController < ApplicationController
       )
     end
 
-    #招待tokenは使用後消す
+    # 招待tokenは使用後消す
     session.delete(:invitation_token)
 
     redirect_to group_path(group), notice: "グループに参加しました"
@@ -42,13 +42,10 @@ class GroupMembershipsController < ApplicationController
   def validate_invitation!
     if @invitation.nil?
       redirect_to root_path, alert: "無効な招待リンクです"
-      return
     elsif @invitation.expired?
       redirect_to root_path, alert: "招待リンクの期限が切れています"
-      return
     elsif @invitation.accepted?
       redirect_to root_path, alert: "この招待リンクはすでに使用されています"
-      return
     end
   end
 end

--- a/app/controllers/group_memberships_controller.rb
+++ b/app/controllers/group_memberships_controller.rb
@@ -1,2 +1,45 @@
 class GroupMembershipsController < ApplicationController
+  before_action :authenticate_user!
+
+  def accept
+    token = session[:invitation_token]
+    invitation = Invitation.find_by(token: token)
+
+    if invitation.nil?
+      redirect_to root_path, alert: "無効な招待です。"
+      return
+    end
+
+    unless invitation.usable?
+      redirect_to root_path, alert: "この招待は使用できません"
+      return
+    end
+
+    group = invitation.group
+
+    if current_user.groups.exists?(group.id)
+      redirect_to group_path(group), notice: "すでにグループに所属しています"
+      return
+    end
+
+    ActiveRecord::Base.transaction do
+      #GroupMembershipを作成して参加
+      GroupMembership.create!(
+        user: current_user,
+        group: group
+      )
+
+      #招待の更新
+      invitation.update!(
+        status: :accepted,
+        used_by: current_user,
+        accepted_at: Time.current
+      )
+    end
+
+    #招待tokenは使用後消す
+    session.delete(:invitation_token)
+
+    redirect_to group_path(group), notice: "グループに参加しました"
+  end
 end

--- a/app/controllers/group_memberships_controller.rb
+++ b/app/controllers/group_memberships_controller.rb
@@ -1,21 +1,10 @@
 class GroupMembershipsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_invitation, only: %i[accept]
+  before_action :validate_invitation!, only: %i[accept]
 
   def accept
-    token = session[:invitation_token]
-    invitation = Invitation.find_by(token: token)
-
-    if invitation.nil?
-      redirect_to root_path, alert: "無効な招待です。"
-      return
-    end
-
-    unless invitation.usable?
-      redirect_to root_path, alert: "この招待は使用できません"
-      return
-    end
-
-    group = invitation.group
+    group = @invitation.group
 
     if current_user.groups.exists?(group.id)
       redirect_to group_path(group), notice: "すでにグループに所属しています"
@@ -30,7 +19,7 @@ class GroupMembershipsController < ApplicationController
       )
 
       #招待の更新
-      invitation.update!(
+      @invitation.update!(
         status: :accepted,
         used_by: current_user,
         accepted_at: Time.current
@@ -41,5 +30,25 @@ class GroupMembershipsController < ApplicationController
     session.delete(:invitation_token)
 
     redirect_to group_path(group), notice: "グループに参加しました"
+  end
+
+  private
+
+  def set_invitation
+    token = session[:invitation_token]
+    @invitation = Invitation.find_by(token: token)
+  end
+
+  def validate_invitation!
+    if @invitation.nil?
+      redirect_to root_path, alert: "無効な招待リンクです"
+      return
+    elsif @invitation.expired?
+      redirect_to root_path, alert: "招待リンクの期限が切れています"
+      return
+    elsif @invitation.accepted?
+      redirect_to root_path, alert: "この招待リンクはすでに使用されています"
+      return
+    end
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -35,13 +35,10 @@ class InvitationsController < ApplicationController
   def validate_invitation!
     if @invitation.nil?
       redirect_to root_path, alert: "無効な招待リンクです"
-      return
     elsif @invitation.expired?
       redirect_to root_path, alert: "招待リンクの期限が切れています"
-      return
     elsif @invitation.accepted?
       redirect_to root_path, alert: "この招待リンクはすでに使用されています"
-      return
     end
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,4 +1,8 @@
 class InvitationsController < ApplicationController
+  before_action :authenticate_user!, only: %i[create]
+  before_action :set_invitation, only: %i[show share]
+  before_action :validate_invitation!, only: %i[show share]
+
   def create
     @group = current_user.groups.find(params[:group_id])
 
@@ -15,34 +19,29 @@ class InvitationsController < ApplicationController
   end
 
   def show
-    @invitation = Invitation.find_by(token: params[:token])
-
-    if @invitation.nil?
-      redirect_to root_path, alert: "無効な招待リンクです"
-      return
-    end
-
-    unless @invitation.usable?
-      redirect_to root_path, alert: "この招待リンクは使用できません"
-      return
-    end
-
-    session[:invitation_token] = params[:token]
+    session[:invitation_token] = @invitation.token
   end
 
   def share
-    @invitation = Invitation.find_by(token: params[:token])
+    @invite_url = "#{request.base_url}#{invitation_path(@invitation.token)}"
+  end
 
+  private
+
+  def set_invitation
+    @invitation = Invitation.find_by(token: params[:token])
+  end
+
+  def validate_invitation!
     if @invitation.nil?
       redirect_to root_path, alert: "無効な招待リンクです"
       return
-    end
-
-    unless @invitation.usable?
-      redirect_to root_path, alert: "この招待リンクは使用できません"
+    elsif @invitation.expired?
+      redirect_to root_path, alert: "招待リンクの期限が切れています"
+      return
+    elsif @invitation.accepted?
+      redirect_to root_path, alert: "この招待リンクはすでに使用されています"
       return
     end
-
-    @invite_url = "#{request.base_url}#{invitation_path(@invitation.token)}"
   end
 end

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -29,9 +29,16 @@
       </div>
 
       <div class="mt-8">
-        <%= link_to "参加する",
-            new_user_registration_path,
-            class: "inline-flex w-full items-center justify-center rounded-2xl bg-teal-600 px-6 py-4 text-lg font-bold text-white shadow-sm transition hover:bg-green-700 focus:outline-none focus:ring-4 focus:ring-green-200" %>
+        <% if user_signed_in? %>
+          <%= button_to "参加する",
+              accept_group_memberships_path,
+              method: :post,
+              class: "inline-flex w-full items-center justify-center rounded-2xl bg-teal-600 px-6 py-4 text-lg font-bold text-white shadow-sm transition hover:bg-green-700 focus:outline-none focus:ring-4 focus:ring-green-200" %>
+        <% else %>
+          <%= link_to "参加する",
+              new_user_registration_path,
+              class: "inline-flex w-full items-center justify-center rounded-2xl bg-teal-600 px-6 py-4 text-lg font-bold text-white shadow-sm transition hover:bg-green-700 focus:outline-none focus:ring-4 focus:ring-green-200" %>
+        <% end %>
       </div>
 
       <p class="mt-4 text-center text-sm text-gray-500">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   get "invitations/:token", to: "invitations#show", as: :invitation
   get "invitations/:token/share", to: "invitations#share", as: :share_invitation
+  post "group_memberships/accept", to: "group_memberships#accept", as: :accept_group_memberships
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## 概要
招待の受託処理の実装とグループ参加機能の実装をしました

## 実装内容
### 1. app/views/invitations/show.html.erbの参加ボタンの分岐を設定
・ログインしていれば、accept_group_memberships_path
・未ログインであれば、new_user_registration_path

### 2. group_memberships_controllerのacceptアクションを設定
・GroupMembershipの作成
・招待リンクの更新
・招待tokenは使用後に消す処理

### 3. 招待リンクを開いてからの認証導線設定
ログイン後にtokenが保存されていれば、invitation_pathへと遷移するように設定
 
## 関連 Issue
Closes #18 