### PR TITLE
Feature/19 add exercise record models

### DIFF
--- a/app/models/exercise_record.rb
+++ b/app/models/exercise_record.rb
@@ -1,0 +1,26 @@
+class ExerciseRecord < ApplicationRecord
+  belongs_to :user
+
+  EXERCISE_TYPES = %w[walk chair_squat heel_raise rest].freeze
+
+  validates :exercise_type, presence: true, inclusion: { in: EXERCISE_TYPES }
+  validates :memo, length: { maximum: 100 }
+  validate :one_record_per_day, on: :create
+
+  private
+
+  def one_record_per_day
+    return if user_id.blank? || exercise_type.blank?
+
+    today_range = Time.current.beginning_of_day..Time.current.end_of_day
+
+    existing_record = ExerciseRecord
+      .where(user_id: user_id)
+      .where(exercise_type: exercise_type)
+      .where(created_at: today_range)
+
+    if existing_record.exists?
+      errors.add(:exercise_type, "は1日1回まで記録できます")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   has_many :groups, through: :group_memberships
   has_many :sent_invitations, class_name: "Invitation", foreign_key: :invited_by_id
   has_many :used_invitations, class_name: "Invitation", foreign_key: :used_by_id
+  has_many :exercise_records, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/db/migrate/20260414015021_create_exercise_records.rb
+++ b/db/migrate/20260414015021_create_exercise_records.rb
@@ -1,0 +1,11 @@
+class CreateExerciseRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :exercise_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :exercise_type, null: false
+      t.text :memo
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_07_045908) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_14_015021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "exercise_records", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "exercise_type", null: false
+    t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_exercise_records_on_user_id"
+  end
 
   create_table "group_memberships", force: :cascade do |t|
     t.bigint "user_id"
@@ -60,6 +69,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_045908) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "exercise_records", "users"
   add_foreign_key "group_memberships", "groups"
   add_foreign_key "group_memberships", "users"
   add_foreign_key "invitations", "groups"

--- a/test/fixtures/exercise_records.yml
+++ b/test/fixtures/exercise_records.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  exercise_type: MyString
+  memo: MyText
+
+two:
+  user: two
+  exercise_type: MyString
+  memo: MyText

--- a/test/models/exercise_record_test.rb
+++ b/test/models/exercise_record_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ExerciseRecordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
exercise_recordモデル、exercise_recordsテーブルの作成をしました

## 実装内容
### 1. rails g model ExerciseRecordを実行

### 2. exercise_recrodsテーブルの編集

### 3. exercise_recordモデルの編集
運動項目の値を固定（walk, chair_squat, heel_raise, rest）
運動項目の記録は1日１種目1回までに設定
バリデーション、アソシエーション設定
userモデルのアソシエーション設定

## 関連 Issue
Closes #19 