### PR TITLE
グループメンバーの今日の運動記録が表示されるように設定しました

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,9 +2,18 @@ class DashboardController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    today_range = Time.current.beginning_of_day..Time.current.end_of_day
+
     @exercise_types = ExerciseRecord::EXERCISE_TYPES
-    @today_exercise_records = current_user.exercise_records.where(
-      created_at: Time.current.beginning_of_day..Time.current.end_of_day
-    )
+    @today_exercise_records = current_user.exercise_records.where(created_at: today_range)
+
+    @group_members = current_user.groups.includes(:users).flat_map(&:users).uniq
+    @group_members = @group_members.reject { |user| user == current_user }
+
+    @group_members_today_records = ExerciseRecord
+      .where(user: @group_members, created_at: today_range)
+      .includes(:user)
+
+    @records_by_user = @group_members_today_records.group_by(&:user_id)
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -72,19 +72,68 @@
                 <% when "rest" %>
                   休み
                 <% end %>
-             </p>
+              </p>
 
-             <p class="mt-1 text-sm text-gray-600">
-               <%= today_record.memo.presence || "メモはありません" %>
-             </p>
-           </div>
+              <p class="mt-1 text-sm text-gray-600">
+                <%= today_record.memo.presence || "メモはありません" %>
+              </p>
+            </div>
 
-           <div class="border-t border-gray-100"></div>
-         <% end %>
+            <div class="border-t border-gray-100"></div>
+          <% end %>
         <% end %>
       <% else %>
         <p class="text-sm text-gray-500">今日はまだ運動記録がありません</p>
       <% end %>
     </div>
+  </section>
+
+  <section class="space-y-4">
+    <h2 class="text-xl font-bold text-gray-900">グループメンバーの今日の運動記録</h2>
+
+    <% if @group_members_today_records.any? %>
+      <% @group_members.each do |member| %>
+        <% member_today_records = @records_by_user[member.id] || [] %>
+
+        <% if member_today_records.any? %>
+          <div class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+            <p class="text-lg font-semibold text-gray-800"><%= member.name %></p>
+
+            <% @exercise_types.each do |exercise_type| %>
+              <% member_record = member_today_records.find { |record| record.exercise_type == exercise_type } %>
+
+              <% if member_record.present? %>
+                <div class="mt-3 border-t border-gray-100 pt-3">
+                  <p class="text-base font-medium text-gray-800">
+                    <% case exercise_type %>
+                    <% when "walk" %>
+                      散歩
+                    <% when "chair_squat" %>
+                      椅子スクワット
+                    <% when "heel_raise" %>
+                      かかと上げ
+                    <% when "rest" %>
+                      休み
+                    <% end %>
+                  </p>
+
+                  <p class="mt-1 text-sm text-gray-600">
+                    <%= member_record.memo.presence || "メモはありません" %>
+                  </p>
+                </div>
+              <% end %>
+            <% end %>
+
+            <div class="mt-4 rounded-lg bg-gray-50 p-3 text-sm text-gray-500">
+              リアクション機能は今後追加予定
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% else %>
+      <p class="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-500">
+        今日はまだグループメンバーの運動記録がありません
+      </p>
+    <% end %>
   </section>
 </div>


### PR DESCRIPTION
## 概要
所属しているグループメンバーで自分を除くメンバーの今日の運動記録を表示されるように実装しました

## 実装内容
### 1. dashboard_controllerのindexアクションを編集
グループメンバーの取得と今日の範囲を設定

### 2. dashboard/index.html.rebの編集
・グループメンバーの記録がある場合、メンバーの名前、運動項目を表示、無ければテンプレート文を表示
・メモがある場合、内容を表示、無ければテンプレート文を表示

## 関連 Issue
Closes #22 