### PR TITLE
タイムゾーンをTokyoに設定しました

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,8 @@ module Myapp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :utc
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
## 概要
タイムゾーンをTokyoに設定しました

## 実装内容
### 1. config/application.rbのタイムゾーンを設定
タイムゾーンをTokyoに設定
<img width="351" height="72" alt="スクリーンショット 2026-04-19 13 12 09" src="https://github.com/user-attachments/assets/dd19ca91-7ede-4dc3-8d46-91864e37545e" />


## 関連 Issue
Closes #97 