### PR TITLE
Feature/28 improve reaction UI

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -80,11 +80,15 @@
 
               <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
                 <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
-                  <span>
-                    <%= emoji %><%= today_record.reactions.where(reaction_type: reaction_type).count %>
-                  </span>
+                  <% count = today_record.reactions.where(reaction_type: reaction_type).count %>
+                  
+                  <% if count > 0 %>
+                    <span class="px-2 py-1 bg-green-100 rounded-full">
+                      <%= emoji %><%= count %>
+                    </span>
+                  <% end %>
                 <% end %>
-            </div>
+              </div>
           <% end %>
         <% end %>
       <% else %>
@@ -128,7 +132,7 @@
 
                   <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
                     <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
-                      <div class="flex items-center gap-1">
+                      <div class="flex items-center gap-1 px-2 py-1 bg-green-100 rounded-full">
                         <%= button_to emoji, reactions_path,
                             params: {
                               exercise_record_id: member_record.id,
@@ -136,7 +140,11 @@
                             },
                             form_class: "inline",
                             class: "inline" %>
-                        <span><%= member_record.reactions.where(reaction_type: reaction_type).count %></span>
+                        <% count = member_record.reactions.where(reaction_type: reaction_type).count %>
+
+                        <% if count > 0 %>
+                          <span><%= count %></span>
+                        <% end %>
                       </div>
                     <% end %>
                   </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -77,6 +77,13 @@
               <p class="mt-1 text-sm text-gray-600">
                 <%= today_record.memo.presence || "メモはありません" %>
               </p>
+
+              <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
+                <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
+                  <span>
+                    <%= emoji %><%= today_record.reactions.where(reaction_type: reaction_type).count %>
+                  </span>
+                <% end %>
             </div>
           <% end %>
         <% end %>
@@ -119,13 +126,18 @@
                     <%= member_record.memo.presence || "メモはありません" %>
                   </p>
 
-                  <div class="mt-2 flex gap-2">
+                  <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
                     <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
-                      <%= button_to emoji, reactions_path,
-                          params: {
-                            exercise_record_id: member_record.id,
-                            reaction_type: reaction_type
-                          } %>
+                      <div class="flex items-center gap-1">
+                        <%= button_to emoji, reactions_path,
+                            params: {
+                              exercise_record_id: member_record.id,
+                              reaction_type: reaction_type
+                            },
+                            form_class: "inline",
+                            class: "inline" %>
+                        <span><%= member_record.reactions.where(reaction_type: reaction_type).count %></span>
+                      </div>
                     <% end %>
                   </div>
                 </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -78,17 +78,18 @@
                 <%= today_record.memo.presence || "メモはありません" %>
               </p>
 
-              <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
+              <div class="mt-2 flex gap-3">
                 <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
                   <% count = today_record.reactions.where(reaction_type: reaction_type).count %>
                   
                   <% if count > 0 %>
-                    <span class="px-2 py-1 bg-green-100 rounded-full">
-                      <%= emoji %><%= count %>
+                    <span class="px-2 py-1 bg-gray-100 text-base font-medium text-gray-700 rounded-full">
+                      <%= emoji %> <%= count %>
                     </span>
                   <% end %>
                 <% end %>
               </div>
+            </div>
           <% end %>
         <% end %>
       <% else %>
@@ -130,9 +131,17 @@
                     <%= member_record.memo.presence || "メモはありません" %>
                   </p>
 
-                  <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
+                  <div class="mt-2 flex gap-3">
                     <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
-                      <div class="flex items-center gap-1 px-2 py-1 bg-green-100 rounded-full">
+
+                      <% reacted = member_record.reactions.where(
+                         user_id: current_user.id,
+                         reaction_type: reaction_type
+                      ).exists? %>
+
+                      <div class="flex items-center gap-1 px-2 py-1 text-base font-medium rounded-full
+                        <%= reacted ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500' %>">
+
                         <%= button_to emoji, reactions_path,
                             params: {
                               exercise_record_id: member_record.id,

--- a/app/views/exercise_records/index.html.erb
+++ b/app/views/exercise_records/index.html.erb
@@ -32,7 +32,15 @@
 
               <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
                 <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
-                  <div class="flex items-center gap-1 px-2 py-1 bg-green-100 rounded-full">
+
+                  <% reacted = record.reactions.where(
+                    user_id: current_user.id,
+                    reaction_type: reaction_type
+                  ).exists? %>
+
+                  <div class="flex items-center gap-1 px-2 py-1 rounded-full
+                    <%= reacted ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500' %>">
+
                     <%= button_to emoji, reactions_path,
                         params: {
                           exercise_record_id: record.id,

--- a/app/views/exercise_records/index.html.erb
+++ b/app/views/exercise_records/index.html.erb
@@ -30,14 +30,19 @@
                 <%= record.memo.presence || "メモはありません" %>
               </p>
 
-              <div class="mt-2 flex gap-2">
+              <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
                 <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
-                  <%= button_to emoji, reactions_path,
-                      params: {
-                      exercise_record_id: record.id,
-                      reaction_type: reaction_type
-                      } %>
-                  <% end %>
+                  <div class="flex items-center gap-1">
+                    <%= button_to emoji, reactions_path,
+                        params: {
+                          exercise_record_id: record.id,
+                          reaction_type: reaction_type
+                        },
+                        form_class: "inline",
+                        class: "inline" %>
+                    <span><%= record.reactions.where(reaction_type: reaction_type).count %></span>
+                  </div>
+                <% end %>
               </div>
             </div>
           <% end %>

--- a/app/views/exercise_records/index.html.erb
+++ b/app/views/exercise_records/index.html.erb
@@ -30,31 +30,46 @@
                 <%= record.memo.presence || "メモはありません" %>
               </p>
 
-              <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
-                <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
+              <div class="mt-2 flex gap-3">
 
-                  <% reacted = record.reactions.where(
-                    user_id: current_user.id,
-                    reaction_type: reaction_type
-                  ).exists? %>
-
-                  <div class="flex items-center gap-1 px-2 py-1 rounded-full
-                    <%= reacted ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500' %>">
-
-                    <%= button_to emoji, reactions_path,
-                        params: {
-                          exercise_record_id: record.id,
-                          reaction_type: reaction_type
-                        },
-                        form_class: "inline",
-                        class: "inline" %>
-
+                <% if @user == current_user %>
+                  <!-- 自分の履歴：件数のみ -->
+                  <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
                     <% count = record.reactions.where(reaction_type: reaction_type).count %>
 
                     <% if count > 0 %>
-                      <span><%= count %></span>
+                      <span class="px-2 py-1 bg-gray-100 text-base font-medium text-gray-700 rounded-full">
+                        <%= emoji %> <%= count %>
+                      </span>
                     <% end %>
-                  </div>
+                  <% end %>
+                <% else %>
+                  <!-- 他人の履歴：ボタンあり -->
+                  <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
+
+                    <% reacted = record.reactions.where(
+                      user_id: current_user.id,
+                      reaction_type: reaction_type
+                    ).exists? %>
+
+                    <div class="flex items-center gap-1 px-2 py-1 text-base font-medium rounded-full
+                      <%= reacted ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500' %>">
+
+                      <%= button_to emoji, reactions_path,
+                          params: {
+                            exercise_record_id: record.id,
+                            reaction_type: reaction_type
+                          },
+                          form_class: "inline",
+                          class: "inline" %>
+
+                      <% count = record.reactions.where(reaction_type: reaction_type).count %>
+
+                      <% if count > 0 %>
+                        <span><%= count %></span>
+                      <% end %>
+                    </div>
+                  <% end %>
                 <% end %>
               </div>
             </div>

--- a/app/views/exercise_records/index.html.erb
+++ b/app/views/exercise_records/index.html.erb
@@ -32,7 +32,7 @@
 
               <div class="mt-2 flex gap-3 text-base font-semibold text-gray-800">
                 <% Reaction::REACTION_EMOJIS.each do |reaction_type, emoji| %>
-                  <div class="flex items-center gap-1">
+                  <div class="flex items-center gap-1 px-2 py-1 bg-green-100 rounded-full">
                     <%= button_to emoji, reactions_path,
                         params: {
                           exercise_record_id: record.id,
@@ -40,7 +40,12 @@
                         },
                         form_class: "inline",
                         class: "inline" %>
-                    <span><%= record.reactions.where(reaction_type: reaction_type).count %></span>
+
+                    <% count = record.reactions.where(reaction_type: reaction_type).count %>
+
+                    <% if count > 0 %>
+                      <span><%= count %></span>
+                    <% end %>
                   </div>
                 <% end %>
               </div>


### PR DESCRIPTION
## 概要
運動記録に対してついたリアクション数を画面に表示する
押したリアクションの見た目変更を行う

## 実装内容
### 1. リアクションの件数を表示する
・リアクションの件数をリアクションボタンの横に表示
・リアクションが０件以上ある場合、数値が表示されるように分岐をする

### 2. リアクションを押した時の見た目変更
・リアクションボタンを押す、押さないで背景色とテキスト色を変更する

### 3. 自分の運動履歴にはボタンにしない
・自分の運動履歴にはリアクションタイプのemojiと件数を表示する

## 関連 Issue
Closes #28 