### PR TITLE
Feature/107 add mypage edit

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,16 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def update_resource(resource, params)
+    if params[:password].present? || params[:password_confirmation].present?
+      resource.update_with_password(params)
+    else
+      params.delete(:current_password)
+      resource.update_without_password(params)
+    end
+  end
+
+  def after_update_path_for(_resource)
+    mypage_path
+  end
+end

--- a/app/helpers/users/registrations_helper.rb
+++ b/app/helpers/users/registrations_helper.rb
@@ -1,0 +1,2 @@
+module Users::RegistrationsHelper
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,42 +1,86 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+<div class="mx-auto max-w-2xl">
+  <div class="mb-6">
+    <h1 class="text-2xl font-bold text-gray-800">プロフィール編集</h1>
+    <p class="mt-2 text-sm text-gray-500">
+      名前、メールアドレス、パスワードを変更できます。
+    </p>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <div class="space-y-6">
+      <section class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 class="text-lg font-bold text-gray-800">基本情報</h2>
+        <p class="mt-1 text-sm text-gray-500">
+          名前とメールアドレスを変更できます。
+        </p>
+
+        <div class="mt-5 space-y-4">
+          <div>
+            <%= f.label :name, "名前", class: "block text-sm font-medium text-gray-700" %>
+            <%= f.text_field :name,
+                             autofocus: true,
+                             autocomplete: "name",
+                             class: "mt-1 block w-full rounded-xl border border-gray-300 px-4 py-3 text-base shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-200" %>
+          </div>
+
+          <div>
+            <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700" %>
+            <%= f.email_field :email,
+                              autocomplete: "email",
+                              class: "mt-1 block w-full rounded-xl border border-gray-300 px-4 py-3 text-base shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-200" %>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 class="text-lg font-bold text-gray-800">パスワード変更</h2>
+        <p class="mt-1 text-sm text-gray-500">
+          パスワードを変更しない場合は、以下の項目は空欄のままで大丈夫です。
+        </p>
+
+        <div class="mt-5 space-y-4">
+          <div>
+            <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700" %>
+            <%= f.password_field :password,
+                                 autocomplete: "new-password",
+                                 class: "mt-1 block w-full rounded-xl border border-gray-300 px-4 py-3 text-base shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-200" %>
+
+            <% if @minimum_password_length %>
+              <p class="mt-1 text-sm text-gray-500">
+                <%= @minimum_password_length %>文字以上で入力してください。
+              </p>
+            <% end %>
+          </div>
+
+          <div>
+            <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-sm font-medium text-gray-700" %>
+            <%= f.password_field :password_confirmation,
+                                 autocomplete: "new-password",
+                                 class: "mt-1 block w-full rounded-xl border border-gray-300 px-4 py-3 text-base shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-200" %>
+          </div>
+
+          <div>
+            <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-medium text-gray-700" %>
+            <%= f.password_field :current_password,
+                                 autocomplete: "current-password",
+                                 class: "mt-1 block w-full rounded-xl border border-gray-300 px-4 py-3 text-base shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-200" %>
+            <p class="mt-1 text-sm text-gray-500">
+              パスワードを変更する場合のみ入力してください。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <div class="flex items-center justify-between">
+        <%= link_to "マイページへ戻る",
+                    mypage_path,
+                    class: "text-sm font-medium text-gray-600 hover:text-gray-800" %>
+
+        <%= f.submit "更新する",
+                     class: "rounded-xl bg-teal-600 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-teal-700" %>
+      </div>
+    </div>
   <% end %>
-
-  <div class="field">
-    <p><%= f.label :password %> <i>(leave blank if you don't want to change it)</i></p>
-    <p><%= f.password_field :password, autocomplete: "new-password" %></p>
-    <% if @minimum_password_length %>
-      <p><em><%= @minimum_password_length %> characters minimum</em></p>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :password_confirmation %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i></p>
-    <p><%= f.password_field :current_password, autocomplete: "current-password" %></p>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+  registrations: "users/registrations"
+  }
 
   root "home#index"
 

--- a/test/controllers/users/registrations_controller_test.rb
+++ b/test/controllers/users/registrations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Users::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
マイページ編集機能を実装しました

## 実装内容
### 1. users/registrations_controller.rbを作成
・DeviseのRegistrationsControllerを継承して更新の時に名前とメールアドレスは現在のパスワード不要、パスワードは現在のパスワード不要となるように上書きする
・ルーティングにユーザーの編集・更新処理でusers/registrations_controller.rbを使うように追記する

### 2. views/devise/registrations/edit.html.erbを編集
・name、email、password、password_confirmation、current_passwordの入力フォームを用意
・naem、emailはcurrent_passwordなく変更できることを確認
・passwordはcurrent_passwordがあると変更できることを確認


## 関連 Issue
Closes #107 