### PR TITLE
Feature/110 handle user deletion relations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,16 @@
 class User < ApplicationRecord
   has_many :group_memberships, dependent: :destroy
   has_many :groups, through: :group_memberships
-  has_many :sent_invitations, class_name: "Invitation", foreign_key: :invited_by_id
-  has_many :used_invitations, class_name: "Invitation", foreign_key: :used_by_id
+  has_many :sent_invitations,
+           class_name: "Invitation",
+           foreign_key: :invited_by_id,
+           dependent: :destroy,
+           inverse_of: :invited_by
+  has_many :used_invitations,
+           class_name: "Invitation",
+           foreign_key: :used_by_id,
+           dependent: :nullify,
+           inverse_of: :used_by
   has_many :exercise_records, dependent: :destroy
   has_many :reactions, dependent: :destroy
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -83,4 +83,19 @@
       </div>
     </div>
   <% end %>
+
+  <section class="mt-8 rounded-2xl border border-red-200 bg-white p-5 shadow-sm">
+    <h2 class="text-lg font-bold text-red-700">アカウント削除</h2>
+    <p class="mt-2 text-sm text-gray-600">
+      アカウントを削除すると、登録情報やこれまでのデータは元に戻せません。
+    </p>
+
+    <div class="mt-4">
+      <%= button_to "アカウントを削除する",
+                    registration_path(resource_name),
+                    data: { turbo_confirm: "本当にアカウントを削除しますか？この操作は元に戻せません。" },
+                    method: :delete,
+                    class: "rounded-xl border border-red-300 bg-white px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50" %>
+    </div>
+  </section>
 </div>


### PR DESCRIPTION
## 概要
アカウント削除時の関連データ処理を設計・実装する

## 実装内容
### 1. userモデルの関連データの設計
・ユーザー削除時にexercise_records、reactions、group_memberships、その人が作成した invitations は削除
・その人が使った invitations の used_by_id は null にする

### 2. マイページ編集画面にアカウント削除ボタンを追加する
・アカウントの削除を確認する

## 関連 Issue
Closes #110 