### PR TITLE
ログイン保持機能後の遷移先をdashboard_pathとする

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
   def index
+    redirect_to dashboard_path if user_signed_in?
   end
 end


### PR DESCRIPTION
## 概要
ログイン保持後の遷移先をログイン後トップページからログイン前トップページへと変更する

## 実装内容
### 1. home_controllerを編集
・ログインしていればdashboard_pathへとリダイレクトするようにする

## 関連 Issue
Closes #145  