### PR TITLE
Feature/50 add notification models

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,4 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+  belongs_to :notifiable, polymorphic: true
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,23 @@
 class Notification < ApplicationRecord
+  NOTIFICATION_TYPES = %w[reaction].freeze
+
   belongs_to :user
   belongs_to :notifiable, polymorphic: true
+
+  validates :notification_type, presence: true, inclusion: { in: NOTIFICATION_TYPES }
+
+  scope :unread, -> { where(read_at: nil) }
+  scope :read, -> { where.not(read_at: nil) }
+
+  def unread?
+    read_at.nil?
+  end
+
+  def read?
+    read_at.present?
+  end
+
+  def mark_as_read!
+    update!(read_at: Time.current)
+  end
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -3,6 +3,7 @@ class Reaction < ApplicationRecord
   REACTION_EMOJIS = { "like" => "👍", "clap" => "👏", "cheer" => "💪" }.freeze
   belongs_to :user
   belongs_to :exercise_record
+  has_many :notifications, as: :notifiable, dependent: :destroy
 
   validates :reaction_type, presence: true, inclusion: { in: REACTION_TYPES }
   validates :reaction_type, uniqueness: { scope: [ :user_id, :exercise_record_id ] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
            inverse_of: :used_by
   has_many :exercise_records, dependent: :destroy
   has_many :reactions, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/db/migrate/20260522054306_create_notifications.rb
+++ b/db/migrate/20260522054306_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :notifiable, polymorphic: true, null: false
+      t.string :notification_type, null: false
+      t.datetime :read_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_19_063809) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_22_054306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_19_063809) do
     t.index ["used_by_id"], name: "index_invitations_on_used_by_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "notifiable_type", null: false
+    t.bigint "notifiable_id", null: false
+    t.string "notification_type", null: false
+    t.datetime "read_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "reactions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "exercise_record_id", null: false
@@ -86,6 +98,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_19_063809) do
   add_foreign_key "invitations", "groups"
   add_foreign_key "invitations", "users", column: "invited_by_id"
   add_foreign_key "invitations", "users", column: "used_by_id"
+  add_foreign_key "notifications", "users"
   add_foreign_key "reactions", "exercise_records"
   add_foreign_key "reactions", "users"
 end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  notifiable: one
+  notifiable_type: Notifiable
+  notification_type: MyString
+  read_at: 2026-05-22 14:43:06
+
+two:
+  user: two
+  notifiable: two
+  notifiable_type: Notifiable
+  notification_type: MyString
+  read_at: 2026-05-22 14:43:06

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
Notificationモデルを作成する

## 実装内容
### 1. NotificationモデルとNotificationsテーブルの生成
・リアクション通知を設定するため、モデルではNOTIFICATION_TYPES = %w[reaction].freezeとする
・notifiableはpolymorphic: trueとして今後複数のモデルと関連付けを想定しています

### 2. UserモデルとReactionモデルの関連付けを行う

## 関連 Issue
Closes #50 