### PR TITLE
Feature/155 add google callback

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,17 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def google_oauth2
+    user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if user&.persisted?
+      sign_in_and_redirect user, event: :authentication
+      set_flash_message(:notice, :success, kind: "Google") if is_navigational_format?
+    else
+      redirect_to new_user_session_path,
+                  alert: "Googleログインに失敗しました。通常登録済みの場合はメールアドレスとパスワードでログインしてください。"
+    end
+  end
+
+  def failure
+    redirect_to new_user_session_path, alert: "認証に失敗しました。もう一度お試しください。"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,30 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: [ :google_oauth2 ]
 
   validates :name, presence: true, length: { maximum: 30 }
+
+  def self.from_omniauth(auth)
+    return nil if auth.provider == "google_oauth2" && !auth.info.email_verified
+    return nil if auth.info.email.blank?
+
+    user = find_by(provider: auth.provider, uid: auth.uid)
+    return user if user
+
+    return nil if exists?(email: auth.info.email)
+
+    create do |u|
+      u.provider = auth.provider
+      u.uid = auth.uid
+      u.email = auth.info.email
+      u.name = auth.info.name.presence || auth.info.email.split("@").first
+      u.password = SecureRandom.hex(16)
+    end
+  end
+
+  def password_required?
+    super && provider.blank?
+  end
+
+  def password_changeable?
+    provider.blank?
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
   devise_for :users, controllers: {
-  registrations: "users/registrations"
+  registrations: "users/registrations",
+  omniauth_callbacks: "users/omniauth_callbacks"
   }
 
   root "home#index"


### PR DESCRIPTION
## 概要
Google認証後のコールバック処理を実装する

## 実装内容
### 1.ルーティング設定
・OmniAuth callback用controllerをdeviseのルーティングに追加

### 2. コントローラー作成
・app/controllers/users/omniauth_callbacks_controller.rbを作成・編集

### 3.app/models/user.rbの編集
・provider / uid でGoogleユーザーを探す
・見つかればそのユーザーを返す
・見つからなければ、同じemailの通常登録ユーザーがいないか確認
・いたら nil を返してGoogleログインを拒否
・いなければGoogleユーザーを新規作成

## 関連 Issue
Closes #155 