### PR TITLE
config.omniauth に callback_url を追加

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -320,12 +320,19 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
   google_client_id = Rails.env.test? ? "dummy-google-client-id" : ENV.fetch("GOOGLE_CLIENT_ID")
   google_client_secret = Rails.env.test? ? "dummy-google-client-secret" : ENV.fetch("GOOGLE_CLIENT_SECRET")
+
+  google_options = {
+    scope: "email,profile",
+    prompt: "select_account"
+  }
+
+  google_options[:callback_url] = ENV.fetch("GOOGLE_OAUTH_CALLBACK_URL") if Rails.env.production?
 
   config.omniauth :google_oauth2,
                   google_client_id,
                   google_client_secret,
-                  scope: "email,profile",
-                  prompt: "select_account"
+                  google_options
 end


### PR DESCRIPTION
本番環境でGoogleログインの動作確認を行いました。

確認内容：
- Renderに GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET / GOOGLE_OAUTH_CALLBACK_URL を設定
- Google Cloud Consoleに独自ドメインのcallback URLを登録
デプロイ後に以下確認：
- ログイン画面からGoogleログイン開始を確認
- 新規登録画面からGoogle登録開始を確認
- Google認証後にdashboardへ遷移することを確認
- 同じGoogleアカウントで再ログインしてもユーザーが重複作成されないことを確認
- 通常登録済みメールとの重複時にGoogleログインが拒否されることを確認
- 通常ログインに影響がないことを確認

## 関連 Issue
Closes #157 
