### PR TITLE
連続記録日数を出す設計を追加する

### DIFF
--- a/app/services/current_streak_calculator.rb
+++ b/app/services/current_streak_calculator.rb
@@ -1,0 +1,52 @@
+require "set"
+
+class CurrentStreakCalculator
+  TIME_ZONE = "Tokyo".freeze
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    record_dates = exercise_record_dates
+    today = today_in_tokyo
+    yesterday = today - 1
+
+    start_date =
+      if record_dates.include?(today)
+        today
+      elsif record_dates.include?(yesterday)
+        yesterday
+      else
+        return 0
+      end
+
+    count_streak_from(start_date, record_dates)
+  end
+
+  private
+
+  attr_reader :user
+
+  def exercise_record_dates
+    user.exercise_records.pluck(:created_at).map do |created_at|
+      created_at.in_time_zone(TIME_ZONE).to_date
+    end.to_set
+  end
+
+  def today_in_tokyo
+    Time.current.in_time_zone(TIME_ZONE).to_date
+  end
+
+  def count_streak_from(start_date, record_dates)
+    streak_count = 0
+    current_date = start_date
+
+    while record_dates.include?(current_date)
+      streak_count += 1
+      current_date -= 1
+    end
+
+    streak_count
+  end
+end


### PR DESCRIPTION
## 概要
現在の連続記録日数を算出する `CurrentStreakCalculator` を実装した。

## 実装内容
### 1.app/services/current_streak_calculator.rbを作成
- ユーザーの運動記録日を日本時間の日付として取得する
- 同じ日に複数記録があっても1日分として扱う
- 今日の記録がある場合は、今日を含めて連続記録を算出する
- 今日の記録がなく、昨日の記録がある場合は、昨日までの連続記録を算出する
- 今日も昨日も記録がない場合は0日を返す
- 記録がない日を挟んだ場合、その日以前は現在の連続記録に含めない

### 2.動作確認
Rails consoleで以下を確認した。

- 運動記録がない場合、`CurrentStreakCalculator.new(user).call` が `0` を返す
- 今日の運動記録を作成後、`CurrentStreakCalculator.new(user).call` が `1` を返す


## 関連 Issue
Closes #55 