### PR TITLE
最長連続記録日数の算出をする

### DIFF
--- a/app/services/longest_streak_calculator.rb
+++ b/app/services/longest_streak_calculator.rb
@@ -21,7 +21,7 @@ class LongestStreakCalculator
         current_streak = 1
       end
 
-      longest_streak = [longest_streak, current_streak].max
+      longest_streak = [ longest_streak, current_streak ].max
       previous_date = current_date
     end
 

--- a/app/services/longest_streak_calculator.rb
+++ b/app/services/longest_streak_calculator.rb
@@ -1,0 +1,40 @@
+class LongestStreakCalculator
+  TIME_ZONE = "Tokyo".freeze
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    record_dates = exercise_record_dates
+
+    return 0 if record_dates.empty?
+
+    longest_streak = 1
+    current_streak = 1
+    previous_date = record_dates.first
+
+    record_dates.drop(1).each do |current_date|
+      if current_date == previous_date + 1
+        current_streak += 1
+      else
+        current_streak = 1
+      end
+
+      longest_streak = [longest_streak, current_streak].max
+      previous_date = current_date
+    end
+
+    longest_streak
+  end
+
+  private
+
+  attr_reader :user
+
+  def exercise_record_dates
+    user.exercise_records.pluck(:created_at).map do |created_at|
+      created_at.in_time_zone(TIME_ZONE).to_date
+    end.uniq.sort
+  end
+end


### PR DESCRIPTION
## 概要
最長連続記録日数の算出を実装する

## 実装内容
### 1.app/services/longest_streak_calculator.rbを作成
- ユーザーごとの最長連続記録日数を算出できる
- 運動記録がない場合は0日が返る
- 1日だけ記録がある場合は1日が返る
- 同日に複数記録があっても1日分として扱われる
- 日本時間（Asia/Tokyo）の日付で判定されている
- 記録が途切れた期間がある場合でも、過去全体の中で最も長い連続日数を返せる
- CurrentStreakCalculator の処理に影響が出ていない

### 2. 動作確認
- Rails consoleで動作確認できている

## 関連 Issue
Closes #217