### PR TITLE
連続記録のバッジ機能の処理を実装

### DIFF
--- a/app/services/streak_badge_selector.rb
+++ b/app/services/streak_badge_selector.rb
@@ -1,0 +1,40 @@
+class StreakBadgeSelector
+  BADGES = [
+    {
+      threshold: 30,
+      name: "1ヶ月達成バッジ",
+      message: "1ヶ月連続達成！",
+      icon: "🏆"
+    },
+    {
+      threshold: 14,
+      name: "2週間達成バッジ",
+      message: "2週間連続達成！",
+      icon: "🏅"
+    },
+    {
+      threshold: 7,
+      name: "1週間達成バッジ",
+      message: "1週間連続達成！",
+      icon: "🔥"
+    },
+    {
+      threshold: 3,
+      name: "3日達成バッジ",
+      message: "3日連続達成！",
+      icon: "🌟"
+    }
+  ].freeze
+
+  def initialize(streak_count)
+    @streak_count = streak_count.to_i
+  end
+
+  def call
+    BADGES.find { |badge| streak_count >= badge[:threshold] }
+  end
+
+  private
+
+  attr_reader :streak_count
+end


### PR DESCRIPTION
## 概要
連続記録日数のバッジ判定の処理を実装

## 実装内容
### 1.app/services/streak_badge_selector.rbを作成
バッジの判定を以下とする
- 3日未満は nil が返る
- 3日以上で3日達成バッジが返る
- 7日以上で1週間達成バッジが返る
- 14日以上で2週間達成バッジが返る
- 30日以上で1ヶ月達成バッジが返る

### 2. 動作確認
- 境界値の動作確認ができている

## 関連 Issue
Closes #218 