### PR TITLE
Feature/139 weekly summary

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,6 +5,7 @@ class DashboardController < ApplicationController
     @current_streak = CurrentStreakCalculator.new(current_user).call
     @longest_streak = LongestStreakCalculator.new(current_user).call
     @streak_badge = StreakBadgeSelector.new(@current_streak).call
+    @weekly_summary = WeeklySummaryCalculator.new(current_user).call
 
     today_range = Time.current.beginning_of_day..Time.current.end_of_day
 

--- a/app/services/weekly_summary_calculator.rb
+++ b/app/services/weekly_summary_calculator.rb
@@ -1,0 +1,45 @@
+class WeeklySummaryCalculator
+  TIME_ZONE = "Tokyo".freeze
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    records = weekly_records
+
+    {
+      recorded_days_count: recorded_days_count(records),
+      exercise_counts: exercise_counts(records),
+      has_records: records.exists?
+    }
+  end
+
+  private
+
+  attr_reader :user
+
+  def weekly_records
+    user.exercise_records.where(created_at: week_range)
+  end
+
+  def week_range
+    today = Time.current.in_time_zone(TIME_ZONE)
+
+    today.beginning_of_week(:monday)..today.end_of_week(:monday)
+  end
+
+  def recorded_days_count(records)
+    records.pluck(:created_at).map do |created_at|
+      created_at.in_time_zone(TIME_ZONE).to_date
+    end.uniq.count
+  end
+
+  def exercise_counts(records)
+    default_counts.merge(records.group(:exercise_type).count)
+  end
+
+  def default_counts
+    ExerciseRecord::EXERCISE_TYPES.index_with(0)
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -30,6 +30,55 @@
     </div>
   </section>
 
+  <section class="mb-6 rounded-lg bg-white p-4 shadow">
+    <h2 class="mb-3 text-lg font-bold text-gray-800">今週のふりかえり</h2>
+
+    <% if @weekly_summary[:has_records] %>
+      <div class="mb-4 rounded-lg bg-blue-50 p-4">
+        <p class="text-sm text-gray-600">今週記録した日数</p>
+        <p class="mt-1 text-2xl font-bold text-blue-700">
+          <%= @weekly_summary[:recorded_days_count] %>日
+        </p>
+      </div>
+
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div class="rounded-lg bg-gray-50 p-3 text-center">
+          <p class="text-sm text-gray-600">散歩</p>
+          <p class="mt-1 text-xl font-bold text-gray-800">
+            <%= @weekly_summary[:exercise_counts]["walk"] %>回
+          </p>
+        </div>
+
+        <div class="rounded-lg bg-gray-50 p-3 text-center">
+          <p class="text-sm text-gray-600">椅子スクワット</p>
+          <p class="mt-1 text-xl font-bold text-gray-800">
+            <%= @weekly_summary[:exercise_counts]["chair_squat"] %>回
+          </p>
+        </div>
+
+        <div class="rounded-lg bg-gray-50 p-3 text-center">
+          <p class="text-sm text-gray-600">かかと上げ</p>
+          <p class="mt-1 text-xl font-bold text-gray-800">
+            <%= @weekly_summary[:exercise_counts]["heel_raise"] %>回
+          </p>
+        </div>
+
+        <div class="rounded-lg bg-gray-50 p-3 text-center">
+          <p class="text-sm text-gray-600">休み</p>
+          <p class="mt-1 text-xl font-bold text-gray-800">
+            <%= @weekly_summary[:exercise_counts]["rest"] %>回
+          </p>
+        </div>
+      </div>
+    <% else %>
+      <div class="rounded-lg bg-gray-50 p-4">
+        <p class="text-sm text-gray-600">
+          今週の記録はまだありません。
+        </p>
+      </div>
+    <% end %>
+  </section>
+
   <section class="space-y-4">
     <h1 class="text-2xl font-bold">今日の運動を記録する</h1>
 


### PR DESCRIPTION
## 概要
週間サマリーのロジックと表示を実装

## 実装内容
### 1. app/services/weekly_summary_calculator.rbを作成
・日本時間の設定、今週を月曜日〜日曜日に設定
・今週の運動記録を取得できる
・今週の記録日数が表示される
・散歩、椅子スクワット、かかと上げ、休みの回数が表示される

### 2. app/controllers/dashboard_controller.rbを編集
・週間サマリーのサービスクラスを追加

### 3. app/views/dashboard/index.html.erbを編集
・トップページに表示する

## 関連 Issue
Closes #139  