### PR TITLE
Feature/170 monthly calendar navigation

### DIFF
--- a/app/controllers/exercise_records_controller.rb
+++ b/app/controllers/exercise_records_controller.rb
@@ -69,7 +69,7 @@ class ExerciseRecordsController < ApplicationController
         current_calendar_month
       end
 
-    [selected_month.beginning_of_month, current_calendar_month].min
+    [ selected_month.beginning_of_month, current_calendar_month ].min
   rescue Date::Error, ArgumentError
     current_calendar_month
   end

--- a/app/controllers/exercise_records_controller.rb
+++ b/app/controllers/exercise_records_controller.rb
@@ -12,8 +12,14 @@ class ExerciseRecordsController < ApplicationController
       .sort_by { |date, _| date }
       .reverse
 
-    @monthly_calendar = MonthlyCalendarBuilder.new(@user).call
-    end
+    selected_month = selected_calendar_month
+
+    @monthly_calendar = MonthlyCalendarBuilder.new(@user, month: selected_month).call
+    @previous_month = @monthly_calendar[:month].prev_month
+    @next_month = @monthly_calendar[:month].next_month
+    @current_month = current_calendar_month
+    @show_next_month_link = @next_month <= @current_month
+  end
 
   def create
     @exercise_record = current_user.exercise_records.new(exercise_record_params)
@@ -53,6 +59,23 @@ class ExerciseRecordsController < ApplicationController
     return if shared_group_exists
 
     redirect_to dashboard_path, alert: "このユーザーの運動履歴は閲覧できません"
+  end
+
+  def selected_calendar_month
+    selected_month =
+      if params[:month].present?
+        Date.strptime(params[:month], "%Y-%m")
+      else
+        current_calendar_month
+      end
+
+    [selected_month.beginning_of_month, current_calendar_month].min
+  rescue Date::Error, ArgumentError
+    current_calendar_month
+  end
+
+  def current_calendar_month
+    Time.current.in_time_zone("Tokyo").to_date.beginning_of_month
   end
 
   def exercise_record_params

--- a/app/views/exercise_records/index.html.erb
+++ b/app/views/exercise_records/index.html.erb
@@ -8,9 +8,25 @@
   <% records_by_date = @monthly_calendar[:records_by_date] %>
 
   <section class="mb-6 rounded-lg bg-white p-4 shadow">
-    <h2 class="mb-3 text-lg font-bold text-gray-800">
-      記録カレンダー <%= calendar_month.strftime("%Y年%-m月") %>
-    </h2>
+    <div class="mb-3 flex items-center justify-between gap-2">
+      <%= link_to "← 前月",
+                  "#{request.path}?#{request.query_parameters.merge(month: @previous_month.strftime('%Y-%m')).to_query}",
+                  class: "rounded-full bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-200" %>
+
+      <h2 class="text-center text-base font-bold text-gray-800">
+        <%= calendar_month.strftime("%Y年%-m月") %>
+      </h2>
+
+      <% if @show_next_month_link %>
+        <%= link_to "翌月 →",
+                    "#{request.path}?#{request.query_parameters.merge(month: @next_month.strftime('%Y-%m')).to_query}",
+                    class: "rounded-full bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-200" %>
+      <% else %>
+        <span class="rounded-full bg-gray-50 px-3 py-2 text-sm font-semibold text-gray-300">
+          翌月 →
+        </span>
+      <% end %>
+    </div>
 
     <div class="grid grid-cols-7 gap-1 text-center text-xs font-semibold text-gray-500">
       <% %w[月 火 水 木 金 土 日].each do |day_name| %>


### PR DESCRIPTION
## 概要
月間カレンダーの翌月・前月の切り替えを実装する

## 実装内容
### 1.app/controllers/exercise_records_controller.rbを編集

- 初期表示では今月を表示する→ params[:month] がなければ current_calendar_month
- 前月リンクを押すと前月を表示する→ @previous_month をリンクに使う
- 翌月リンクを押すと翌月を表示する→ @next_month をリンクに使う
- 未来月は制限する→ @show_next_month_link と selected_calendar_month の min で制御
- 不正なURLでも画面が落ちない→ rescue で今月に戻す

### 2. app/views/exercise_records/index.html.erbの編集
・前月と翌月のリンクを追加

### 4 . 動作確認
- 初期表示で今月のカレンダーが表示される
- 前月リンクを押すと前月のカレンダーが表示される
- 前月表示中に翌月リンクを押すと翌月へ戻れる
- 今月表示中は翌月リンクが無効になっている
- 表示中の年月が中央に表示される
- 月を切り替えても対象ユーザーの記録だけが表示される
- 既存の運動履歴一覧が残っている

## 関連 Issue
Closes #170   