### PR TITLE
Feature/167 add body memo feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ gem "resend"
 
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
+
+gem "openai", "~> 0.68.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,10 @@ GEM
     omniauth-rails_csrf_protection (2.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    openai (0.68.0)
+      base64
+      cgi
+      connection_pool
     orm_adapter (0.5.0)
     parallel (1.27.0)
     parser (3.3.11.1)
@@ -431,6 +435,7 @@ DEPENDENCIES
   letter_opener_web
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  openai (~> 0.68.0)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)
@@ -529,6 +534,7 @@ CHECKSUMS
   omniauth-google-oauth2 (1.2.2) sha256=74c3f3d0221c048f938846092fb15a1f15237526f50a7c93d9793f9a4ff1be11
   omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
   omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d
+  openai (0.68.0) sha256=fbb542babd5291b77c286154f015226a2e3bb74495cfc0694044cbefa42e63b3
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,6 +6,7 @@ class DashboardController < ApplicationController
     @longest_streak = LongestStreakCalculator.new(current_user).call
     @streak_badge = StreakBadgeSelector.new(@current_streak).call
     @weekly_summary = WeeklySummaryCalculator.new(current_user).call
+    @body_memo = BodyMemoGenerator.new(user: current_user).call
 
     today_range = Time.current.beginning_of_day..Time.current.end_of_day
 

--- a/app/models/body_memo.rb
+++ b/app/models/body_memo.rb
@@ -1,0 +1,6 @@
+class BodyMemo < ApplicationRecord
+  belongs_to :user
+
+  validates :memo_date, presence: true, uniqueness: { scope: :user_id }
+  validates :content, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   has_many :reactions, dependent: :destroy
   has_many :notifications, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :body_memos, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/services/body_memo_generator.rb
+++ b/app/services/body_memo_generator.rb
@@ -1,0 +1,134 @@
+class BodyMemoGenerator
+  FALLBACK_CONTENT = "今日も記録できていて素晴らしいです。無理のない範囲で、姿勢や足元に気をつけながら続けていきましょう。".freeze
+  NO_RECORD_CONTENT = "今日の運動記録をすると、からだメモが表示されます。".freeze
+
+  def initialize(user:, date: Time.zone.today)
+    @user = user
+    @date = date
+  end
+
+  def call
+    existing_memo = BodyMemo.find_by(user: user, memo_date: date)
+    return existing_memo if existing_memo.present?
+
+    return no_record_body_memo if today_exercise_records.blank?
+
+    content = generate_content
+
+    if content.blank?
+      create_body_memo!(content: FALLBACK_CONTENT, fallback: true)
+    else
+      create_body_memo!(content: content, fallback: false)
+    end
+  rescue StandardError => e
+    Rails.logger.warn("[BodyMemoGenerator] #{e.class}: #{e.message}")
+
+    create_body_memo!(
+      content: FALLBACK_CONTENT,
+      fallback: true
+    )
+  end
+
+  private
+
+  attr_reader :user, :date
+
+  def generate_content
+    response = client.responses.create(
+      model: ENV.fetch("OPENAI_MODEL", "gpt-5.4-mini"),
+      input: [
+        { role: :system, content: system_prompt },
+        { role: :user, content: user_prompt }
+      ],
+      request_options: {
+        timeout: 10
+      }
+    )
+
+    response.output
+            .flat_map(&:content)
+            .filter_map { |content| content[:text] || content["text"] }
+            .join
+            .strip
+  end
+
+  def client
+    @client ||= OpenAI::Client.new(
+      api_key: ENV.fetch("OPENAI_API_KEY")
+    )
+  end
+
+  def today_exercise_records
+    @today_exercise_records ||= user.exercise_records
+                                    .where(created_at: date.all_day)
+                                    .order(:created_at)
+  end
+
+  def user_prompt
+    exercise_names = today_exercise_records.map do |record|
+      exercise_type_name(record.exercise_type)
+    end
+
+    memo_texts = today_exercise_records.map(&:memo).filter_map(&:presence)
+
+    <<~PROMPT
+      今日の運動記録は以下です。
+
+      運動内容:
+      #{exercise_names.join("、")}
+
+      ユーザーのメモ:
+      #{memo_texts.presence&.join(" / ") || "なし"}
+
+      上記をもとに、今日のからだメモを作成してください。
+    PROMPT
+  end
+
+  def system_prompt
+    <<~PROMPT
+      あなたは家族で運動習慣を続けるアプリ「ファミリーステップ」の応援コメント作成者です。
+
+      以下の条件を必ず守ってください。
+
+      - 日本語で書く
+      - 80文字以内
+      - やさしく前向きな表現にする
+      - 医療的な効果を断定しない
+      - 痛み、病気、治療、診断に関する助言をしない
+      - 「治る」「改善する」「予防できる」「効果がある」と断定しない
+      - 運動時の注意点を1つ入れる
+      - 運動を続けることで期待できる一般的なメリットをやわらかく伝える
+      - 不安をあおらない
+      - 専門的すぎる表現は避ける
+    PROMPT
+  end
+
+  def exercise_type_name(exercise_type)
+    {
+      "walk" => "散歩",
+      "chair_squat" => "椅子スクワット",
+      "heel_raise" => "踵上げ",
+      "rest" => "休息"
+    }.fetch(exercise_type, exercise_type)
+  end
+
+  def create_body_memo!(content:, fallback:)
+    BodyMemo.create!(
+      user: user,
+      memo_date: date,
+      content: content.presence || FALLBACK_CONTENT,
+      fallback: fallback
+    )
+  rescue ActiveRecord::RecordNotUnique
+    BodyMemo.find_by!(user: user, memo_date: date)
+  end
+
+  def no_record_body_memo
+    BodyMemo.new(
+      user: user,
+      memo_date: date,
+      content: NO_RECORD_CONTENT,
+      fallback: true
+    )
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -270,4 +270,35 @@
       </p>
     <% end %>
   </section>
+
+  <section class="rounded-2xl bg-white p-5 shadow-sm">
+    <div class="flex items-center justify-between gap-3">
+      <div>
+       <h2 class="text-lg font-bold text-gray-800">
+          今日のからだメモ
+        </h2>
+        <p class="mt-1 text-sm text-gray-500">
+          今日の運動記録をもとに、ひとことメモを表示します。
+        </p>
+      </div>
+
+      <% if @body_memo&.fallback? %>
+        <span class="shrink-0 rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500">
+          通常コメント
+        </span>
+      <% end %>
+    </div>
+
+    <div class="mt-4 rounded-xl bg-teal-50 p-4">
+      <p class="text-sm leading-6 text-gray-700">
+        <%= @body_memo&.content || "今日の運動記録をすると、からだメモが表示されます。" %>
+      </p>
+    </div>
+
+    <% if @body_memo.present? && !@body_memo.persisted? %>
+      <p class="mt-2 text-xs text-gray-500">
+        運動記録後に、AIによるからだメモが生成されます。
+      </p>
+    <% end %>
+  </section>
 </div>

--- a/db/migrate/20260629145746_create_body_memos.rb
+++ b/db/migrate/20260629145746_create_body_memos.rb
@@ -9,6 +9,6 @@ class CreateBodyMemos < ActiveRecord::Migration[7.2]
       t.timestamps
     end
 
-    add_index :body_memos, [:user_id, :memo_date], unique: true
+    add_index :body_memos, [ :user_id, :memo_date ], unique: true
   end
 end

--- a/db/migrate/20260629145746_create_body_memos.rb
+++ b/db/migrate/20260629145746_create_body_memos.rb
@@ -1,0 +1,14 @@
+class CreateBodyMemos < ActiveRecord::Migration[7.2]
+  def change
+    create_table :body_memos do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :memo_date, null: false
+      t.text :content, null: false
+      t.boolean :fallback, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :body_memos, [:user_id, :memo_date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_24_141051) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_29_145746) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "body_memos", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "memo_date", null: false
+    t.text "content", null: false
+    t.boolean "fallback", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "memo_date"], name: "index_body_memos_on_user_id_and_memo_date", unique: true
+    t.index ["user_id"], name: "index_body_memos_on_user_id"
+  end
 
   create_table "comments", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -105,6 +116,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_24_141051) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "body_memos", "users"
   add_foreign_key "comments", "exercise_records"
   add_foreign_key "comments", "users"
   add_foreign_key "exercise_records", "users"

--- a/test/fixtures/body_memos.yml
+++ b/test/fixtures/body_memos.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  memo_date: 2026-06-29
+  content: MyText
+  fallback: false
+
+two:
+  user: two
+  memo_date: 2026-06-29
+  content: MyText
+  fallback: false

--- a/test/models/body_memo_test.rb
+++ b/test/models/body_memo_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BodyMemoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
AI APIで今日のからだメモを生成・保存を実装する

## 実装内容
### 1.gem導入
・gem "openai", "~> 0.68.0"

### 2. 環境変数の設定
・openaiでAPIkeyを取得、.env、Renderに追加

### 3. BodyMemoモデルを作成、周辺モデルの関連付け

### 4. app/services/body_memo_generator.rbを作成
・プロンプトは医療的な効果を断定、診断のような表現は避ける。運動時の注意点を入れる様にする。

### 5. dashboard/index.html.erbにからだメモを追加

### 4 . 動作確認
- 運動記録ありの日にAIコメントが表示される
- BodyMemoにcontentが保存される
- 同じ日にBodyMemoが重複作成されない
- 運動記録なしの日は固定文表示だけでDB保存されない
- APIエラー時もdashboardが落ちない
- fallback: trueで固定文が保存される
- プロンプトが医療助言になっていない

## 関連 Issue
Closes #167 