### PR TITLE
からだメモの表示デザインの改善、からだメモのパーシャル化を実装する

### DIFF
--- a/app/views/dashboard/_body_memo_card.html.erb
+++ b/app/views/dashboard/_body_memo_card.html.erb
@@ -1,0 +1,49 @@
+<section class="rounded-3xl border border-teal-100 bg-gradient-to-br from-teal-50 via-white to-white p-4 shadow-sm sm:p-5">
+  <div class="flex items-start gap-3">
+    <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-white text-2xl shadow-sm">
+      🌿
+    </div>
+
+    <div class="min-w-0 flex-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <h2 class="text-base font-bold text-gray-800 sm:text-lg">
+          今日のからだメモ
+        </h2>
+
+        <% if body_memo&.persisted? && body_memo&.fallback? %>
+          <span class="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-500">
+            通常コメント
+          </span>
+        <% elsif body_memo&.persisted? %>
+          <span class="rounded-full bg-teal-100 px-2.5 py-1 text-xs font-medium text-teal-700">
+            AIメモ
+          </span>
+        <% else %>
+          <span class="rounded-full bg-orange-50 px-2.5 py-1 text-xs font-medium text-orange-600">
+            記録後に生成
+          </span>
+        <% end %>
+      </div>
+
+      <p class="mt-1 text-xs leading-5 text-gray-500 sm:text-sm">
+        今日の運動記録をもとに、無理なく続けるためのひとことを表示します。
+      </p>
+
+      <div class="mt-4 rounded-2xl bg-white/80 p-4 shadow-sm">
+        <p class="break-words text-sm leading-7 text-gray-700 sm:text-base sm:leading-8">
+          <%= (body_memo&.content).presence || "今日の運動記録をすると、からだメモが表示されます。" %>
+        </p>
+      </div>
+
+      <% if body_memo.present? && !body_memo.persisted? %>
+        <p class="mt-3 text-xs leading-5 text-gray-500">
+          まずは今日の運動を記録してみましょう。記録後に、からだメモが表示されます。
+        </p>
+      <% elsif body_memo&.fallback? %>
+        <p class="mt-3 text-xs leading-5 text-gray-500">
+          AIコメントを生成できなかったため、通常コメントを表示しています。
+        </p>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -141,6 +141,8 @@
     </div>
   </section>
 
+  <%= render "body_memo_card", body_memo: @body_memo %>
+
   <section class="space-y-4">
     <h2 class="text-xl font-bold text-gray-900">
       <%= current_user.name %>さんの今日の運動記録
@@ -267,37 +269,6 @@
     <% else %>
       <p class="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-500">
         今日はまだグループメンバーの運動記録がありません
-      </p>
-    <% end %>
-  </section>
-
-  <section class="rounded-2xl bg-white p-5 shadow-sm">
-    <div class="flex items-center justify-between gap-3">
-      <div>
-       <h2 class="text-lg font-bold text-gray-800">
-          今日のからだメモ
-        </h2>
-        <p class="mt-1 text-sm text-gray-500">
-          今日の運動記録をもとに、ひとことメモを表示します。
-        </p>
-      </div>
-
-      <% if @body_memo&.fallback? %>
-        <span class="shrink-0 rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500">
-          通常コメント
-        </span>
-      <% end %>
-    </div>
-
-    <div class="mt-4 rounded-xl bg-teal-50 p-4">
-      <p class="text-sm leading-6 text-gray-700">
-        <%= @body_memo&.content || "今日の運動記録をすると、からだメモが表示されます。" %>
-      </p>
-    </div>
-
-    <% if @body_memo.present? && !@body_memo.persisted? %>
-      <p class="mt-2 text-xs text-gray-500">
-        運動記録後に、AIによるからだメモが生成されます。
       </p>
     <% end %>
   </section>


### PR DESCRIPTION
## 概要
からだメモのデザインの修正を行う

## 実装内容
### 1. からだメモのデザイン変更
- カード内に絵文字を追加し、視覚的に内容が伝わりやすいデザインに変更
- からだメモの状態に応じて表示ラベルを切り替え
  - 未記録時：`記録後に生成`
  - AI生成済み：`AIメモ`
  - フォールバック表示時：`通常コメント`
- 未生成時の補足文を追加し、ユーザーが次に何をすればよいか分かるように調整
- 長文になった場合でもカードが崩れにくいように `break-words` を追加

### 2. パーシャル化
- _body_memo_card.html.erbにからだメモの内容を追加してすっきりさせる

## 関連 Issue
Closes #184 