### PR TITLE
Feature/146 add guest login

### DIFF
--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -1,0 +1,15 @@
+class GuestSessionsController < ApplicationController
+  def create
+    if user_signed_in?
+      redirect_to dashboard_path
+      return
+    end
+
+    guest_user = User.create_guest!
+    sign_in guest_user
+
+    redirect_to dashboard_path, notice: "ゲストユーザーとしてログインしました。"
+  rescue ActiveRecord::RecordInvalid
+    redirect_to root_path, alert: "ゲストログインに失敗しました。時間をおいて再度お試しください。"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,4 +50,13 @@ class User < ApplicationRecord
   def password_changeable?
     provider.blank?
   end
+
+  def self.create_guest!
+    create!(
+      name: "ゲストユーザー",
+      email: "guest_#{SecureRandom.uuid}@example.com",
+      password: SecureRandom.urlsafe_base64,
+      guest: true
+    )
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   omniauth_callbacks: "users/omniauth_callbacks"
   }
 
+  post "guest_login", to: "guest_sessions#create", as: :guest_login
+
   root "home#index"
 
   resources :groups do

--- a/db/migrate/20260709030911_add_guest_to_users.rb
+++ b/db/migrate/20260709030911_add_guest_to_users.rb
@@ -1,0 +1,6 @@
+class AddGuestToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :guest, :boolean, null: false, default: false
+    add_index :users, :guest
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_29_145746) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_09_030911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -111,7 +111,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_29_145746) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.boolean "guest", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["guest"], name: "index_users_on_guest"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
ゲストログイン機能の追加を実装

## 実装内容
### 1.userテーブルにguestカラムを追加
- 通常ユーザーは guest: false
- ゲストユーザーは guest: true

### 2. userモデルにゲストユーザー作成の処理を追加
- ゲストログイン時にユニークなメールアドレスを持つゲストユーザーを作成
- ランダムなパスワードを設定

### 3. GuestSessionsController#create を追加
- 未ログイン時はゲストユーザーを作成してログイン
- ログイン後はダッシュボードへ遷移
- ログイン済みの場合は新しいゲストユーザーを作成せず、ダッシュボードへ遷移

### 4. guest_login_path 用のルーティングを追加
- POST /guest_login でゲストログイン処理を実行

### 5 . 動作確認
- 仮のログインボタンを作成し、ログインできることを確認後に削除

## 関連 Issue
Closes #146 