### PR TITLE
Feature/148 restrict guest account

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,6 @@
 class Users::RegistrationsController < Devise::RegistrationsController
+before_action :ensure_not_guest_user, only: %i[edit update destroy]
+
   protected
 
   def update_resource(resource, params)
@@ -12,5 +14,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def after_update_path_for(_resource)
     mypage_path
+  end
+
+  private
+
+  def ensure_not_guest_user
+    return unless current_user&.guest?
+
+    redirect_to mypage_path, alert: "ゲストユーザーはアカウントの編集・削除できません。"
   end
 end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -17,10 +17,16 @@
       </div>
     </div>
 
-    <div class="mt-6">
-      <%= link_to "編集する",
-                  edit_user_registration_path,
-                  class: "inline-flex items-center rounded-xl bg-teal-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-700" %>
-    </div>
+    <% if current_user.guest? %>
+      <p class="mt-6 text-sm text-gray-500">
+        ゲストユーザーは編集できません
+      </p>
+    <% else %>
+      <div class="mt-6">
+        <%= link_to "編集する",
+                    edit_user_registration_path,
+                    class: "inline-flex items-center rounded-xl bg-teal-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-700" %>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
ゲストユーザーがアカウント編集・削除を行えないように、画面上の導線制御とコントローラー側のアクセス制限を追加しました。

## 実装内容
### 1.app/controllers/users/registrations_controller.rbの編集
- `Users::RegistrationsController` にゲストユーザー制限処理を追加
  - `edit`
  - `update`
  - `destroy`
- ゲストユーザーがアカウント編集・削除にアクセスした場合、マイページへリダイレクトするように変更

### 2. app/views/mypages/show.html.erbの編集
- マイページでゲストユーザーには編集ボタンを表示しないように変更
- ゲストユーザー向けに「ゲストユーザーは編集できません」という説明文を表示
- 通常ユーザーはこれまで通りアカウント編集できるように維持

### 3. 動作確認
- ゲストユーザーでログインした場合、マイページに編集ボタンが表示されないことを確認
- ゲストユーザーで `/users/edit` に直接アクセスした場合、マイページへリダイレクトされることを確認
- ゲストユーザー向けの制限メッセージが表示されることを確認
- 通常ユーザーでログインした場合、これまで通り編集ボタンが表示されることを確認
- 通常ユーザーで編集ページへ遷移できることを確認
- 通常ログイン・通常ユーザーの編集導線に影響がないことを確認


## 関連 Issue
Closes #148 