### PR TITLE
Feature/149 add guest sample data

### DIFF
--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -5,7 +5,12 @@ class GuestSessionsController < ApplicationController
       return
     end
 
-    guest_user = User.create_guest!
+    guest_user = ActiveRecord::Base.transaction do
+      user = User.create_guest!
+      GuestSampleDataCreator.new(user).call
+      user
+    end
+
     sign_in guest_user
 
     redirect_to dashboard_path, notice: "ゲストユーザーとしてログインしました。"

--- a/app/services/guest_sample_data_creator.rb
+++ b/app/services/guest_sample_data_creator.rb
@@ -1,0 +1,78 @@
+class GuestSampleDataCreator
+  def initialize(guest_user)
+    @guest_user = guest_user
+  end
+
+  def call
+    group = create_group
+    sample_users = create_sample_users
+
+    add_users_to_group(group, sample_users)
+    create_exercise_records(sample_users)
+  end
+
+  private
+
+  attr_reader :guest_user
+
+  def create_group
+    Group.create!(name: "ゲスト家族")
+  end
+
+  def create_sample_users
+    [
+      create_sample_users("お父さん"),
+      create_sample_users("お母さん")
+    ]
+  end
+
+  def create_sample_users(name)
+    User.create!(
+      name: name,
+      email: "guest_sample_#{SecureRandom.uuid}@example.com",
+      password: SecureRandom.urlsafe_base64,
+      guest: true
+    )
+  end
+
+  def add_users_to_group(group, sample_users)
+    GroupMembership.create!(
+      user: guest_user,
+      group: group,
+      role: :admin
+    )
+
+    sample_users.each do |sample_user|
+      GroupMembership.create!(
+        user: sample_user,
+        group: group,
+        role: :member
+      )
+    end
+  end
+
+  def create_exercise_records(sample_users)
+    father, mother = sample_users
+
+    ExerciseRecord.create!(
+      user: father,
+      exercise_type: "walk",
+      memo: "今日は近所をゆっくり散歩しました。",
+      created_at: Time.current
+    )
+
+    ExerciseRecord.create!(
+      user: mother,
+      exercise_type: "heel_raise",
+      memo: "テレビを見ながらかかと上げをしました。",
+      created_at: Time.current
+    )
+
+    ExerciseRecord.create!(
+      user: father,
+      exercise_type: "chair_squat",
+      memo: "昨日は椅子スクワットを無理なく行いました。",
+      created_at: 1.day.ago
+    )
+  end
+end

--- a/app/services/guest_sample_data_creator.rb
+++ b/app/services/guest_sample_data_creator.rb
@@ -21,12 +21,12 @@ class GuestSampleDataCreator
 
   def create_sample_users
     [
-      create_sample_users("お父さん"),
-      create_sample_users("お母さん")
+      create_sample_user("お父さん"),
+      create_sample_user("お母さん")
     ]
   end
 
-  def create_sample_users(name)
+  def create_sample_user(name)
     User.create!(
       name: name,
       email: "guest_sample_#{SecureRandom.uuid}@example.com",


### PR DESCRIPTION
## 概要
ゲストログイン時に、ゲストユーザー用のグループ・サンプル家族ユーザー・サンプル運動記録を作成し、ログイン直後から家族の記録が確認できるようにしました

## 実装内容
### 1.GuestSampleDataCreatorサービスクラスを作成
- ゲスト用グループ「ゲスト家族」を作成
  - サンプル家族ユーザー「お父さん」「お母さん」を作成
  - ゲストユーザーとサンプル家族ユーザーを同じグループに所属
  - サンプル家族ユーザーの運動記録を作成
  
### 2. guest_sessions_controller.rbを編集
- ゲストログイン時に `GuestSampleDataCreator` を呼び出すように変更
- ゲストユーザー作成とサンプルデータ作成を transaction でまとめるように変更
- サンプル家族ユーザーも `guest: true` として作成

### 3 . 動作確認
- ゲストログイン後、ダッシュボードへ遷移することを確認
- ゲスト用グループ「ゲスト家族」が作成されることを確認
- サンプル家族ユーザー「お父さん」「お母さん」が作成されることを確認
- お父さん・お母さんの運動記録が表示されることを確認
- ゲストユーザー本人が通常通り運動記録できることを確認
- 通常ログインに影響がないことを確認

## 関連 Issue
Closes #149  