### PR TITLE
Feature/230 cleanup guest users

### DIFF
--- a/app/controllers/admin/guest_user_cleanups_controller.rb
+++ b/app/controllers/admin/guest_user_cleanups_controller.rb
@@ -1,0 +1,19 @@
+class Admin::GuestUserCleanupsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :ensure_admin_user
+
+  def create
+    result = GuestUserCleanupService.new.call
+
+    redirect_to mypage_path,
+                notice: "ゲストデータ削除が完了しました。削除ユーザー: #{result[:deleted_users]}件、削除グループ: #{result[:deleted_groups]}件"
+  end
+
+  private
+
+  def ensure_admin_user
+    return if admin_user?
+
+    redirect_to root_path, alert: "権限がありません。"
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  helper_method :admin_user?
+
   def after_sign_in_path_for(resource)
     if session[:invitation_token].present?
       invitation_path(session[:invitation_token])
@@ -21,5 +23,13 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+  end
+
+  private
+
+  def admin_user?
+    current_user.present? &&
+      ENV["ADMIN_EMAIL"].present? &&
+      current_user.email == ENV["ADMIN_EMAIL"]
   end
 end

--- a/app/services/guest_user_cleanup_service.rb
+++ b/app/services/guest_user_cleanup_service.rb
@@ -1,0 +1,47 @@
+class GuestUserCleanupService
+  DEFAULT_RETENTION_DAYS = 7
+
+  def initialize(retention_days: DEFAULT_RETENTION_DAYS)
+    @cutoff_time = retention_days.days.ago
+  end
+
+  def call
+    groups = old_guest_only_groups
+    users = old_guest_users
+
+    deleted_group_count = groups.count
+    deleted_user_count = users.count
+
+    ActiveRecord::Base.transaction do
+      groups.each(&:destroy!)
+
+      users.find_each do |user|
+        user.destroy!
+      end
+    end
+
+    {
+      deleted_users: deleted_user_count,
+      deleted_groups: deleted_group_count,
+      cutoff_time: cutoff_time
+    }
+  end
+
+  private
+
+  attr_reader :cutoff_time
+
+  def old_guest_users
+    User.where(guest: true).where("created_at < ?", cutoff_time)
+  end
+
+  def old_guest_only_groups
+    Group
+      .includes(:users)
+      .where("groups.created_at < ?", cutoff_time)
+      .select do |group|
+        group.users.any? &&
+          group.user.all? { |user| user.guest? && user.created_at < cutoff_time }
+      end
+  end
+end

--- a/app/services/guest_user_cleanup_service.rb
+++ b/app/services/guest_user_cleanup_service.rb
@@ -41,7 +41,7 @@ class GuestUserCleanupService
       .where("groups.created_at < ?", cutoff_time)
       .select do |group|
         group.users.any? &&
-          group.user.all? { |user| user.guest? && user.created_at < cutoff_time }
+          group.users.all? { |user| user.guest? && user.created_at < cutoff_time }
       end
   end
 end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -28,5 +28,23 @@
                     class: "inline-flex items-center rounded-xl bg-teal-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-700" %>
       </div>
     <% end %>
+
+    <% if admin_user? %>
+      <div class="mt-8 rounded-2xl border border-red-200 bg-red-50 p-5">
+        <h2 class="text-base font-bold text-red-700">
+          管理者メニュー
+        </h2>
+
+        <p class="mt-2 text-sm text-red-600">
+          作成から一定期間が経過したゲストユーザーと関連データを削除します。
+        </p>
+
+        <%= button_to "古いゲストデータを削除する",
+                      admin_guest_user_cleanup_path,
+                      method: :post,
+                      data: { turbo_confirm: "古いゲストユーザーと関連データを削除します。実行しますか？" },
+                      class: "mt-4 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,4 +44,8 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+
+  namespace :admin do
+    resource :guest_user_cleanup, only: :create
+  end
 end

--- a/lib/tasks/guest_users.rake
+++ b/lib/tasks/guest_users.rake
@@ -1,0 +1,13 @@
+namespace :guest_users do
+  desc "Delete old guest users and related data"
+  task cleanup: :environment do
+    retention_days = ENV.fetch("GUEST_USER_RETENTION_DAYS", 7).to_i
+
+    result = GuestUserCleanupService.new(retention_days: retention_days).call
+
+    puts "Guest user cleanup completed."
+    puts "Deleted users: #{result[:deleted_users]}"
+    puts "Deleted groups: #{result[:deleted_groups]}"
+    puts "Cutoff time: #{result[:cutoff_time]}"
+  end
+end


### PR DESCRIPTION
## 概要
作成から一定期間が経過したゲストユーザーと、ゲストユーザーのみで構成されたゲスト用グループを削除できるようにしました。

## 実装内容
### 1.`GuestUserCleanupService` を追加
  - `guest: true` のユーザーを削除対象に設定
  - 作成から一定期間が経過したゲストユーザーを削除
  - ゲストユーザーのみで構成された古いグループを削除
  - 通常ユーザーが所属するグループは削除対象外
  - 削除処理を `transaction` で実行

### 2.`guest_users:cleanup` Rakeタスクを追加
  - 以下のコマンドで手動実行可能

    ```bash
    bin/rails guest_users:cleanup
    ```

  - `GUEST_USER_RETENTION_DAYS` により保持日数を変更可能

    ```bash
    GUEST_USER_RETENTION_DAYS=3 bin/rails guest_users:cleanup
    ```

### 3. 管理者専用のゲストデータ削除導線を追加
  - `ADMIN_EMAIL` と一致するユーザーのみ削除ボタンを表示
  - 管理者以外は削除処理を実行できないようにコントローラー側でも制限
  - 削除実行後、削除ユーザー数・削除グループ数をフラッシュメッセージで表示


### 4 . 動作確認
- `bin/rails guest_users:cleanup` を実行し、古いゲストユーザー3件・ゲストグループ1件が削除されることを確認
- ゲストユーザーに紐づく関連データが削除されることを確認
- 通常ユーザーが削除されないことを確認
- 管理者メールアドレスでログインした場合のみ、ゲストデータ削除ボタンが表示されることを確認
- 管理者ボタンから削除処理を実行できることを確認
- 削除対象がない場合、削除ユーザー0件・削除グループ0件として正常終了することを確認
- 管理者以外には削除ボタンが表示されないことを確認

## 補足

無料運用を想定しているため、現時点ではRender Cron Jobやwheneverによる自動実行は設定していません。

本番環境では、管理者専用ボタンから手動で削除処理を実行できるようにしています。

将来的に定期実行を導入する場合は、追加したRakeタスクをCron Job等に設定することで対応できます。


## 関連 Issue
Closes #230   