### PR TITLE
フッターナビゲーションを作成しました

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,10 +17,10 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="bg-orange-50 text-gray-800">
+  <body class="min-h-screen bg-orange-50 text-gray-800">
     <%= render 'shared/header' %>
 
-    <main class="max-w-3xl mx-auto px-4 pt-20">
+    <main class="max-w-3xl mx-auto px-4 pt-20 <%= user_signed_in? ? 'pb-24' : 'pb-8' %>">
       <% if notice.present? %>
         <div class="mb-4 rounded-xl border border-teal-300 bg-teal-50 px-4 py-3 text-teal-800">
           <%= notice %>
@@ -35,5 +35,7 @@
 
       <%= yield %>
     </main>
+
+    <%= render "shared/footer" if user_signed_in? %>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,28 @@
+<footer class="fixed inset-x-0 bottom-0 z-20 border-t border-gray-200 bg-white">
+  <nav class="mx-auto grid h-16 max-w-3xl grid-cols-3">
+    <% home_active = controller_name == "dashboard" %>
+    <% groups_active = controller_name == "groups" %>
+    <% notifications_active = controller_name == "notifications" %>
+
+    <%= link_to dashboard_path,
+        class: "flex h-full w-full flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition
+          #{home_active ? 'text-teal-600' : 'text-gray-500 hover:text-gray-700'}" do %>
+      <%= render "shared/menu_icon", icon_name: "home" %>
+      <span>ホーム</span>
+    <% end %>
+
+    <%= link_to groups_path,
+        class: "flex h-full w-full flex-col items-center justify-center gap-1 border-l border-gray-200 py-2 text-xs font-medium transition
+          #{groups_active ? 'text-teal-600' : 'text-gray-500 hover:text-gray-700'}" do %>
+      <%= render "shared/menu_icon", icon_name: "user-group" %>
+      <span>グループ一覧</span>
+    <% end %>
+
+    <%= link_to notifications_path,
+        class: "flex h-full w-full flex-col items-center justify-center gap-1 border-l border-gray-200 py-2 text-xs font-medium transition
+          #{notifications_active ? 'text-teal-600' : 'text-gray-500 hover:text-gray-700'}" do %>
+      <%= render "shared/menu_icon", icon_name: "bell" %>
+      <span>通知一覧</span>
+    <% end %>
+  </nav>
+</footer>


### PR DESCRIPTION
## 概要
ログイン中の主要画面に固定フッターナビゲーションを追加しました。

## 実装内容
### 1.app/views/shared/_footer.html.erbを編集
- フッターにリンクを追加（ホーム、グループ一覧、通知一覧）
- 各リンクにHeroiconsのSVGアイコンを表示

### 2 . 動作確認

- ログイン中にフッターナビゲーションが表示される
- ホームへ遷移できる
- グループ一覧へ遷移できる
- 通知一覧へ遷移できる
- 各リンクにHeroiconsが表示される
- dashboardでホームが選択状態になる
- グループ関連画面でグループ一覧が選択状態になる
- 通知一覧画面で通知一覧が選択状態になる
- 各列の余白部分を押してもページ遷移できる
- フッターがページ下部のコンテンツに重ならない
- ハンバーガーメニューを開いた際にログアウト部分が隠れない
- ハンバーガーメニューの既存の開閉動作に影響がない
- ログイン中の主要画面で表示崩れがない

## 関連 Issue
Closes #182   