### PR TITLE
使い方ページの導線をログイン前トップページとハンバーガーメニューに追加しました

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -33,6 +33,10 @@
           登録せずにアプリの画面をお試しいただけます。
         </p>
       </div>
+
+      <%= link_to "使い方を見る",
+            usage_path,
+            class: "inline-flex min-h-12 items-center justify-center rounded-xl border-2 border-teal-400 bg-white px-6 py-3 text-base font-bold text-teal-700 transition hover:bg-teal-50" %>
     </div>
   </div>
 
@@ -72,5 +76,11 @@
       <li>家族グループを作成して、家族を招待します</li>
       <li>運動を記録し、家族の記録にリアクションします</li>
     </ol>
+
+    <div class="mt-6 text-center">
+      <%= link_to "詳しい使い方を見る",
+                  usage_path,
+                  class: "font-bold text-teal-700 underline underline-offset-4 hover:text-teal-800" %>
+    </div>
   </div>
 </section>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -75,20 +75,11 @@
           </p>
 
           <div class="mt-2 space-y-1">
-            <div
-              class="flex min-h-10 items-center gap-3 rounded-lg px-3 py-1.5 text-gray-400"
-              aria-disabled="true"
-            >
+            <%= link_to usage_path,
+                class: "flex min-h-10 items-center gap-3 rounded-lg px-3 py-1.5 text-left text-gray-700 transition hover:bg-gray-100" do %>
               <%= render "shared/menu_icon", icon_name: "question-mark-circle" %>
-
-              <span class="flex-1">
-                使い方
-              </span>
-
-              <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
-                準備中
-              </span>
-            </div>
+              <span>使い方</span>
+            <% end %>
 
             <div
               class="flex min-h-10 items-center gap-3 rounded-lg px-3 py-1.5 text-gray-400"


### PR DESCRIPTION
## 概要
ログイン前トップページに使い方ページへの導線を追加

## 実装内容
### 1.ログイン前トップページに導線を追加
- トップページ上部と使い方欄の中に導線を追加

### 2. ハンバーガーメニューに導線を追加

### 3 .動作確認
- ログアウト状態でトップページに「使い方を見る」が表示される
- 「使い方を見る」から使い方ページへ遷移できる
- 「詳しい使い方を見る」から使い方ページへ遷移できる
- ハンバーガーメニューの「使い方」から遷移できる
- 未ログイン状態でも使い方ページを閲覧できる 

## 関連 Issue
Closes #151  