### PR TITLE
Feature/130 add privacy policy

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,4 +4,7 @@ class PagesController < ApplicationController
 
   def terms
   end
+
+  def privacy_policy
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -68,6 +68,10 @@
         <%= link_to "利用規約",
                     terms_path,
                     class: "font-medium text-teal-700 underline underline-offset-4 hover:text-teal-800" %>
+        および
+        <%= link_to "プライバシーポリシー",
+                    privacy_policy_path,
+                    class: "font-medium text-teal-700 underline underline-offset-4 hover:text-teal-800" %>
         に同意したものとします。
       </p>
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,467 @@
+<section class="mx-auto max-w-4xl">
+  <div class="rounded-2xl bg-white px-6 py-8 shadow-sm sm:px-10">
+    <header class="border-b border-gray-200 pb-6">
+      <h1 class="text-2xl font-bold text-gray-800 sm:text-3xl">
+        プライバシーポリシー
+      </h1>
+
+      <p class="mt-4 text-sm leading-7 text-gray-600 sm:text-base">
+        ファミリーステップ運営者（以下「運営者」といいます。）は、
+        ウェブサービス「ファミリーステップ」（以下「本サービス」といいます。）における
+        利用者の情報について、以下のとおりプライバシーポリシー
+        （以下「本ポリシー」といいます。）を定めます。
+      </p>
+    </header>
+
+    <article class="mt-8 space-y-10 text-sm leading-7 text-gray-700 sm:text-base">
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第1条（取得する情報）
+        </h2>
+
+        <p class="mt-4">
+          運営者は、本サービスの提供にあたり、次の情報を取得または取り扱います。
+        </p>
+
+        <ol class="mt-4 list-decimal space-y-5 pl-6">
+          <li>
+            <span class="font-semibold text-gray-800">
+              アカウントおよび認証に関する情報
+            </span>
+
+            <ul class="mt-2 list-disc space-y-1 pl-6">
+              <li>名前</li>
+              <li>メールアドレス</li>
+              <li>認証情報</li>
+              <li>パスワード再設定に関する情報</li>
+              <li>ログイン状態の保持に関する情報</li>
+              <li>ゲスト利用に関する情報</li>
+            </ul>
+
+            <p class="mt-2">
+              パスワードは認証のためにハッシュ化した状態で保存し、
+              利用者が入力した文字列をそのまま保持しません。
+            </p>
+          </li>
+
+          <li>
+            <span class="font-semibold text-gray-800">
+              Googleアカウントによるログインに関する情報
+            </span>
+
+            <ul class="mt-2 list-disc space-y-1 pl-6">
+              <li>Googleアカウントに登録された名前</li>
+              <li>Googleアカウントのメールアドレス</li>
+              <li>メールアドレスの確認状態</li>
+              <li>認証に必要な識別情報</li>
+            </ul>
+
+            <p class="mt-2">
+              運営者がGoogleアカウントのパスワードを取得することはありません。
+            </p>
+          </li>
+
+          <li>
+            <span class="font-semibold text-gray-800">
+              グループに関する情報
+            </span>
+
+            <ul class="mt-2 list-disc space-y-1 pl-6">
+              <li>グループ名</li>
+              <li>グループへの所属情報</li>
+              <li>グループ内での役割および権限</li>
+              <li>グループへの招待に関する情報</li>
+            </ul>
+          </li>
+
+          <li>
+            <span class="font-semibold text-gray-800">
+              運動記録に関する情報
+            </span>
+
+            <ul class="mt-2 list-disc space-y-1 pl-6">
+              <li>運動種目</li>
+              <li>運動記録の日時</li>
+              <li>利用者が入力した運動メモ</li>
+            </ul>
+
+            <p class="mt-2">
+              運動メモには、利用者が任意に入力した健康状態、
+              身体状態その他の情報が含まれる場合があります。
+            </p>
+          </li>
+
+          <li>
+            <span class="font-semibold text-gray-800">
+              コミュニケーションに関する情報
+            </span>
+
+            <ul class="mt-2 list-disc space-y-1 pl-6">
+              <li>コメントの内容、投稿者および投稿日時</li>
+              <li>リアクションの種類、実行者および実行日時</li>
+              <li>通知の種類、通知対象および既読状態</li>
+            </ul>
+          </li>
+
+          <li>
+            <span class="font-semibold text-gray-800">
+              AIによって生成される情報
+            </span>
+
+            <ul class="mt-2 list-disc space-y-1 pl-6">
+              <li>運動記録をもとに生成された「からだメモ」</li>
+              <li>からだメモの対象日および生成状態</li>
+            </ul>
+          </li>
+
+          <li>
+            <span class="font-semibold text-gray-800">
+              お問い合わせに関する情報
+            </span>
+
+            <ul class="mt-2 list-disc space-y-1 pl-6">
+              <li>名前</li>
+              <li>メールアドレス</li>
+              <li>お問い合わせ内容</li>
+            </ul>
+
+            <p class="mt-2">
+              お問い合わせ情報は、本サービスのデータベースには保存せず、
+              メール送信およびお問い合わせ対応のために取り扱います。
+            </p>
+          </li>
+
+          <li>
+            <span class="font-semibold text-gray-800">
+              本サービスの利用に伴って取得する情報
+            </span>
+
+            <ul class="mt-2 list-disc space-y-1 pl-6">
+              <li>Cookieおよびセッションに関する情報</li>
+              <li>アクセス日時</li>
+              <li>IPアドレス</li>
+              <li>ブラウザや端末に関する情報</li>
+              <li>エラーおよび操作に関するログ情報</li>
+            </ul>
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第2条（情報の利用目的）
+        </h2>
+
+        <p class="mt-4">
+          運営者は、取得した情報を次の目的で利用します。
+        </p>
+
+        <ol class="mt-3 list-decimal space-y-2 pl-6">
+          <li>本サービスの利用登録、本人確認および認証のため</li>
+          <li>本サービスの各機能を提供するため</li>
+          <li>運動記録および運動習慣に関する情報を表示するため</li>
+          <li>グループ内で運動記録などを共有するため</li>
+          <li>リアクション、コメントおよび通知機能を提供するため</li>
+          <li>AIを利用して「からだメモ」を生成するため</li>
+          <li>パスワード再設定などの案内を送信するため</li>
+          <li>お問い合わせへの回答および必要な連絡を行うため</li>
+          <li>本サービスの保守、不具合調査および改善のため</li>
+          <li>不正利用の防止および安全性の確保のため</li>
+          <li>本規約または本ポリシーの変更などを案内するため</li>
+          <li>その他、上記の利用目的に付随する目的のため</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第3条（グループ内での情報共有）
+        </h2>
+
+        <ol class="mt-4 list-decimal space-y-2 pl-6">
+          <li>
+            利用者の名前、運動記録、運動メモ、コメントおよびリアクションは、
+            同じグループに所属する利用者に表示されます。
+          </li>
+          <li>
+            利用者は、グループ内で共有されることを理解したうえで、
+            自己の責任において情報を登録するものとします。
+          </li>
+          <li>
+            運動メモやコメントには、病歴、診断内容、治療内容その他の
+            必要以上に詳細な健康・医療情報を入力しないよう注意してください。
+          </li>
+          <li>
+            第三者に関する情報を入力する場合は、
+            必要に応じて当該第三者の同意を得てください。
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第4条（AI機能における情報の取扱い）
+        </h2>
+
+        <ol class="mt-4 list-decimal space-y-2 pl-6">
+          <li>
+            本サービスでは、「からだメモ」の生成にOpenAI APIを利用します。
+          </li>
+          <li>
+            からだメモの生成に必要な範囲で、
+            当日の運動種目および運動メモをOpenAI APIへ送信します。
+          </li>
+          <li>
+            からだメモの生成時に、利用者の名前、メールアドレス、
+            パスワード、グループ名、コメント、リアクションおよび
+            通知情報はOpenAI APIへ送信しません。
+          </li>
+          <li>
+            OpenAIへ送信された情報は、
+            OpenAIが定める規約およびデータ取扱方針に従って処理されます。
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第5条（外部サービスの利用）
+        </h2>
+
+        <p class="mt-4">
+          本サービスでは、サービスの提供および運営に必要な範囲で、
+          次の外部サービスを利用します。
+        </p>
+
+        <div class="mt-4 overflow-x-auto">
+          <table class="w-full min-w-2xl border-collapse text-left text-sm">
+            <thead>
+              <tr class="border-b border-gray-300 bg-gray-50">
+                <th class="px-4 py-3 font-semibold text-gray-800">
+                  外部サービス
+                </th>
+                <th class="px-4 py-3 font-semibold text-gray-800">
+                  利用目的
+                </th>
+                <th class="px-4 py-3 font-semibold text-gray-800">
+                  取り扱われる主な情報
+                </th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr class="border-b border-gray-200">
+                <td class="px-4 py-3">Google</td>
+                <td class="px-4 py-3">Googleアカウントによるログイン</td>
+                <td class="px-4 py-3">
+                  名前、メールアドレス、認証識別情報など
+                </td>
+              </tr>
+
+              <tr class="border-b border-gray-200">
+                <td class="px-4 py-3">OpenAI</td>
+                <td class="px-4 py-3">からだメモの生成</td>
+                <td class="px-4 py-3">運動種目、運動メモ</td>
+              </tr>
+
+              <tr class="border-b border-gray-200">
+                <td class="px-4 py-3">Resend</td>
+                <td class="px-4 py-3">各種メールの送信</td>
+                <td class="px-4 py-3">
+                  メールアドレス、メールの件名および本文
+                </td>
+              </tr>
+
+              <tr class="border-b border-gray-200">
+                <td class="px-4 py-3">Google Gmail</td>
+                <td class="px-4 py-3">お問い合わせの受信および対応</td>
+                <td class="px-4 py-3">
+                  名前、メールアドレス、お問い合わせ内容
+                </td>
+              </tr>
+
+              <tr class="border-b border-gray-200">
+                <td class="px-4 py-3">Render</td>
+                <td class="px-4 py-3">
+                  アプリケーションおよびデータベースの運用
+                </td>
+                <td class="px-4 py-3">本サービスで保存する情報</td>
+              </tr>
+
+              <tr>
+                <td class="px-4 py-3">Cloudflare</td>
+                <td class="px-4 py-3">
+                  ドメイン、通信およびセキュリティの管理
+                </td>
+                <td class="px-4 py-3">
+                  IPアドレス、アクセス情報など
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p class="mt-4">
+          各外部サービスに送信された情報は、
+          各事業者が定める規約およびプライバシーポリシーに従って取り扱われます。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第6条（第三者提供および取扱いの委託）
+        </h2>
+
+        <ol class="mt-4 list-decimal space-y-2 pl-6">
+          <li>
+            運営者は、法令に基づく場合を除き、
+            利用者本人の同意なく個人情報を第三者に提供しません。
+          </li>
+          <li>
+            運営者は、本サービスの提供、メール送信、AIによる文章生成、
+            サーバー運用その他の目的に必要な範囲で、
+            外部サービス事業者に情報の取扱いを委託または送信することがあります。
+          </li>
+          <li>
+            外部サービス事業者には、日本国外に所在する事業者が
+            含まれる場合があります。
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第7条（Cookie等の利用）
+        </h2>
+
+        <ol class="mt-4 list-decimal space-y-2 pl-6">
+          <li>
+            本サービスでは、ログイン状態の維持、認証および
+            セキュリティ確保のため、Cookieその他の類似技術を使用します。
+          </li>
+          <li>
+            利用者は、ブラウザの設定によりCookieを無効にできますが、
+            その場合、本サービスの一部の機能を利用できないことがあります。
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第8条（情報の保存および削除）
+        </h2>
+
+        <ol class="mt-4 list-decimal space-y-2 pl-6">
+          <li>
+            運営者は、本サービスの提供に必要な期間、
+            利用者の情報を保存します。
+          </li>
+          <li>
+            利用者が退会した場合、登録情報および投稿内容は、
+            法令上またはサービス運営上保存が必要な場合を除き、
+            本サービスの仕様に従って削除または匿名化します。
+          </li>
+          <li>
+            ゲスト利用によって作成されたアカウントおよび関連情報は、
+            一定期間の経過後に削除されることがあります。
+          </li>
+          <li>
+            お問い合わせ情報は本サービスのデータベースには保存しませんが、
+            問い合わせ対応に必要な期間、メールサービス上で保存される場合があります。
+          </li>
+          <li>
+            バックアップ、ログまたは外部サービス上の情報については、
+            削除後も一定期間保存される場合があります。
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第9条（安全管理措置）
+        </h2>
+
+        <p class="mt-4">
+          運営者は、利用者の情報への不正アクセス、漏えい、紛失、
+          改ざんその他の事故を防止するため、アクセス制御、
+          認証情報の適切な管理、通信の保護その他の必要かつ合理的な
+          安全管理措置を講じるよう努めます。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第10条（情報の開示・訂正・削除等）
+        </h2>
+
+        <ol class="mt-4 list-decimal space-y-2 pl-6">
+          <li>
+            利用者は、本サービス上の機能を利用して、
+            自身の登録情報を確認または変更できます。
+          </li>
+          <li>
+            利用者本人から、個人情報の利用目的の通知、開示、
+            訂正、追加、削除、利用停止または消去の申し出があった場合、
+            運営者は本人確認を行ったうえで、法令に従って対応します。
+          </li>
+          <li>
+            対応を希望する場合は、本ポリシー末尾の
+            お問い合わせフォームからご連絡ください。
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第11条（未成年者の利用）
+        </h2>
+
+        <p class="mt-4">
+          未成年者が本サービスを利用する場合は、
+          親権者その他の法定代理人の同意を得たうえで利用してください。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第12条（プライバシーポリシーの変更）
+        </h2>
+
+        <ol class="mt-4 list-decimal space-y-2 pl-6">
+          <li>
+            運営者は、法令の変更、本サービスの内容変更
+            その他の必要に応じて、本ポリシーを変更することがあります。
+          </li>
+          <li>
+            本ポリシーを変更する場合、変更内容および効力発生日を、
+            本サービス上での表示その他の適切な方法によって周知します。
+          </li>
+          <li>
+            変更後の本ポリシーは、周知した効力発生日から適用されます。
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-gray-800 sm:text-xl">
+          第13条（お問い合わせ）
+        </h2>
+
+        <p class="mt-4">
+          本ポリシーおよび利用者の情報の取扱いに関するお問い合わせは、
+          次のお問い合わせフォームからご連絡ください。
+        </p>
+
+        <div class="mt-4">
+          <%= link_to "お問い合わせフォームへ",
+                      new_contact_path,
+                      class: "font-medium text-teal-700 underline decoration-teal-300 underline-offset-4 hover:text-teal-800" %>
+        </div>
+      </section>
+    </article>
+
+    <footer class="mt-10 border-t border-gray-200 pt-6 text-right text-sm leading-6 text-gray-500">
+      <p>制定日：2026年8月6日</p>
+      <p>ファミリーステップ運営者</p>
+    </footer>
+  </div>
+</section>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -93,20 +93,11 @@
               <span>利用規約</span>
             <% end %>
 
-            <div
-              class="flex min-h-10 items-center gap-3 rounded-lg px-3 py-1.5 text-gray-400"
-              aria-disabled="true"
-            >
+            <%= link_to privacy_policy_path,
+                class: "flex min-h-10 items-center gap-3 rounded-lg px-3 py-1.5 text-left text-gray-700 transition hover:bg-gray-100" do %>
               <%= render "shared/menu_icon", icon_name: "shield-check" %>
-
-              <span class="flex-1">
-                プライバシーポリシー
-              </span>
-
-              <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
-                準備中
-              </span>
-            </div>
+              <span>プライバシーポリシー</span>
+            <% end %>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   get "mypage", to: "mypages#show", as: :mypage
   get "usage", to: "pages#usage", as: :usage
   get "terms", to: "pages#terms", as: :terms
+  get "privacy_policy", to: "pages#privacy_policy", as: :privacy_policy
   post "group_memberships/accept", to: "group_memberships#accept", as: :accept_group_memberships
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 概要
ファミリーステップのプライバシーポリシーページを追加しました。

本サービスで取得・保存する情報、利用目的、グループ内での共有、外部サービスでの取扱いなどを、現在の実装内容に合わせて記載しています。

## 実装内容
### 1.プライバシーポリシーページを作成

- PagesControllerにprivacy_policyアクションを追加
- プライバシーポリシーページのルーティングを追加
- /privacy_policyでプライバシーポリシーを表示できるように変更
- ハンバーガーメニューにプライバシーポリシーへのリンクを追加
- 新規登録画面にプライバシーポリシーへの同意案内とリンクを追加
- プライバシーポリシー内にお問い合わせフォームへのリンクを追加
- 利用規約ページと統一したレイアウトを適用

### 2. 動作確認

- /privacy_policyへアクセスできること
- ログアウト状態でもプライバシーポリシーを閲覧できること
- ハンバーガーメニューからプライバシーポリシーへ遷移できること
- 新規登録画面からプライバシーポリシーへ遷移できること
- 新規登録画面に利用規約とプライバシーポリシーの同意案内が表示されること
- プライバシーポリシー内のお問い合わせリンクが動作すること
- 外部サービスの表がスマートフォン表示で横スクロールできること
- 利用規約ページとレイアウトが統一されていること
- 文章やリンクが画面からはみ出さないこと

## 関連 Issue
Closes #130 