### PR TITLE
運動記録機能のrspecを実装

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -498,7 +498,7 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9

--- a/spec/factories/exercise_records.rb
+++ b/spec/factories/exercise_records.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :exercise_record do
+    association :user
+    exercise_type { "walk" }
+    memo { "散歩しました" }
+  end
+end

--- a/spec/models/exercise_record_spec.rb
+++ b/spec/models/exercise_record_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe ExerciseRecord, type: :model do
+  describe "バリデーション" do
+    it "有効な運動記録を作成できる" do
+      exercise_record = build(:exercise_record)
+
+      expect(exercise_record).to be_valid
+    end
+
+    it "exercise_typeが未入力の場合は無効である" do
+      exercise_record = build(:exercise_record, exercise_type: nil)
+
+      expect(exercise_record).not_to be_valid
+    end
+
+    it "同じ日に同じ運動を重複して記録できない" do
+      user = create(:user)
+
+      create(
+        :exercise_record,
+        user: user,
+        exercise_type: "walk"
+      )
+
+      duplicate_record = build(
+        :exercise_record,
+        user: user,
+        exercise_type: "walk"
+      )
+
+      expect(duplicate_record).not_to be_valid
+    end
+
+    it "翌日なら同じ運動を記録できる" do
+      user = create(:user)
+
+      create(
+        :exercise_record,
+        user: user,
+        exercise_type: "walk"
+      )
+
+      travel_to 1.day.from_now do
+        next_day_record = build(
+          :exercise_record,
+          user: user,
+          exercise_type: "walk"
+        )
+
+        expect(next_day_record).to be_valid
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')

--- a/spec/requests/exercise_records_spec.rb
+++ b/spec/requests/exercise_records_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe "ExerciseRecords", type: :request do
+  describe "POST /exercise_records" do
+    context "ログインしている場合" do
+      it "運動記録を作成できる" do
+        user = create(:user)
+
+        post user_session_path, params: {
+          user: {
+            email: user.email,
+            password: "password123"
+          }
+        }
+
+        expect {
+          post exercise_records_path, params: {
+            exercise_record: {
+              exercise_type: "walk"
+            }
+          }
+        }.to change(ExerciseRecord, :count).by(1)
+
+        record = ExerciseRecord.last
+
+        expect(record.user).to eq(user)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "運動記録を作成できない" do
+        expect {
+          post exercise_records_path, params: {
+            exercise_record: {
+              exercise_type: "walk"
+            }
+          }
+        }.not_to change(ExerciseRecord, :count)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "PATCH /exercise_records/:id" do
+    context "自分の運動記録の場合" do
+      it "メモを更新できる" do
+        user = create(:user)
+
+        post user_session_path, params: {
+          user: {
+            email: user.email,
+            password: "password123"
+          }
+        }
+
+        record = create(
+          :exercise_record,
+          user: user,
+          memo: "更新前のメモ"
+        )
+
+        patch exercise_record_path(record), params: {
+          exercise_record: {
+            memo: "更新後のメモ"
+          }
+        }
+
+        expect(record.reload.memo).to eq("更新後のメモ")
+      end
+    end
+
+    context "他人の運動記録の場合" do
+      it "メモを更新できない" do
+        user = create(:user)
+        other_user = create(:user)
+
+        post user_session_path, params: {
+          user: {
+            email: user.email,
+            password: "password123"
+          }
+        }
+
+        record = create(
+          :exercise_record,
+          user: other_user,
+          memo: "更新前のメモ"
+        )
+
+        patch exercise_record_path(record), params: {
+          exercise_record: {
+            memo: "更新後のメモ"
+          }
+        }
+
+        expect(response).to have_http_status(:not_found)
+        expect(record.reload.memo).to eq("更新前のメモ")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
運動記録機能に対するModel Spec・Request Specを追加しました。

## 実装内容
### 1.ExerciseRecord Model Spec

- 有効な運動記録を作成できることを確認
- exercise_type が未入力の場合は無効になることを確認
- 同じユーザーが同じ日に同じ種目を重複して記録できないことを確認
- 翌日であれば同じ種目を記録できることを確認
- 日付を変更したテストを行うため、RSpecで ActiveSupport::Testing::TimeHelpers を利用できるよう設定

### 2 . ExerciseRecord Request Spec

- ログインユーザーが運動記録を作成できることを確認
- 作成した運動記録がログインユーザーに紐づくことを確認
- 未ログイン状態では運動記録を作成できないことを確認
- 未ログイン時にログイン画面へリダイレクトされることを確認
- 自分の運動記録のメモを更新できることを確認
- 他人の運動記録を編集しようとした場合に404になることを確認
- 他人の運動記録のメモが変更されないことを確認


### 2 . 動作確認
- bundle exec rspec が正常に実行できることを確認


## 関連 Issue
Closes #174  