### PR TITLE
グループ作成のテスト追加

### DIFF
--- a/spec/factories/group_memberships.rb
+++ b/spec/factories/group_memberships.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :group_membership do
+    association :user
+    association :group
+    role { :member }
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :group do
+    name { "テストグループ" }
+  end
+end

--- a/spec/models/group_membership_spec.rb
+++ b/spec/models/group_membership_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe GroupMembership, type: :model do
+  describe "バリデーション" do
+    it "有効なグループメンバーシップを作成できる" do
+      user = create(:user)
+      group = create(:group)
+      membership = build(
+        :group_membership,
+        user: user,
+        group: group
+      )
+
+      expect(membership).to be_valid
+    end
+
+    it "同じユーザーを同じグループに重複して登録できない" do
+      user = create(:user)
+      group = create(:group)
+
+      create(
+        :group_membership,
+        user: user,
+        group: group
+      )
+
+      duplicate_membership = build(
+        :group_membership,
+        user: user,
+        group: group
+      )
+
+      expect(duplicate_membership).not_to be_valid
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Group, type: :model do
+  describe "バリデーション" do
+    it "有効なグループを作成できる" do
+      group = build(:group)
+
+      expect(group).to be_valid
+    end
+
+    it "グループ名が未入力の場合は無効である" do
+      group = build(:group, name: nil)
+
+      expect(group).not_to be_valid
+    end
+  end
+end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe "Groups", type: :request do
+  describe "POST /groups" do
+    context "ログインしている場合" do
+      it "グループを作成できる" do
+        user = create(:user)
+
+        post user_session_path, params: {
+          user: {
+            email: user.email,
+            password: "password123"
+          }
+        }
+
+        expect {
+          post groups_path, params: {
+            group: {
+              name: "テストグループ"
+            }
+          }
+        }.to change(Group, :count).by(1)
+
+        group = Group.last
+
+        membership = GroupMembership.find_by(
+          group: group,
+          user: user
+        )
+
+        expect(membership).to be_present
+        expect(membership).to be_admin
+      end
+
+      it "作成したグループが一覧に表示される" do
+        user = create(:user)
+
+        post user_session_path, params: {
+          user: {
+            email: user.email,
+            password: "password123"
+          }
+        }
+
+        post groups_path, params: {
+          group: {
+            name: "テストグループ"
+          }
+        }
+
+        get groups_path
+
+        expect(response.body).to include("テストグループ")
+      end
+    end
+
+    context "未ログインの場合" do
+      it "グループを作成できない" do
+        expect {
+          post groups_path, params: {
+            group: {
+              name: "テストグループ"
+            }
+          }
+        }.not_to change(Group, :count)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
グループ作成機能に対するModel Spec・Request Specを追加しました。

## 実装内容
### 1.Group Model Spec

- 有効なグループを作成できることを確認
- グループ名が未入力の場合は無効になることを確認

### 2 .GroupMembership Model Spec

- 有効なGroupMembershipを作成できることを確認
- 同じユーザーを同じグループに重複して登録できないことを確認

### 3 .Group Request Spec

- ログインユーザーがグループを作成できることを確認
- グループ作成時にGroupMembershipが作成されることを確認
- グループ作成者がadminとして登録されることを確認
- 作成したグループがグループ一覧に表示されることを確認
- 未ログイン時はグループを作成できないことを確認
- 未ログイン時はログイン画面へリダイレクトされることを確認

### 4 . 動作確認
- bundle exec rspec が正常に実行できることを確認

## 関連 Issue
Closes #175  