### PR TITLE
招待機能のrspecを追加しました

### DIFF
--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :invitation do
+    association :group
+    association :invited_by, factory: :user
+    expires_at { 7.days.from_now }
+  end
+end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe Invitation, type: :model do
+  describe "バリデーション" do
+    it "有効な招待を作成できる" do
+      invitation = build(:invitation)
+
+      expect(invitation).to be_valid
+    end
+
+    it "招待ごとに異なるトークンが生成される" do
+      invitation1 = create(:invitation)
+      invitation2 = create(:invitation)
+
+      expect(invitation1.token).not_to eq(invitation2.token)
+    end
+  end
+
+  describe "#expired?" do
+    it "有効期限内の場合はfalseを返す" do
+      invitation = build(
+        :invitation,
+        expires_at: 1.day.from_now
+      )
+
+      expect(invitation.expired?).to eq(false)
+    end
+
+    it "有効期限切れの場合はtrueを返す" do
+      invitation = build(
+        :invitation,
+        expires_at: 1.day.ago
+      )
+
+      expect(invitation.expired?).to eq(true)
+    end
+  end
+
+  describe "#usable?" do
+    it "未使用かつ有効期限内の場合はtrueを返す" do
+      invitation = build(
+        :invitation,
+        status: :pending,
+        expires_at: 1.day.from_now,
+        used_by: nil
+      )
+
+      expect(invitation.usable?).to eq(true)
+    end
+
+    it "有効期限切れの場合はfalseを返す" do
+      invitation = build(
+        :invitation,
+        status: :pending,
+        expires_at: 1.day.ago,
+        used_by: nil
+      )
+
+      expect(invitation.usable?).to eq(false)
+    end
+
+    it "acceptedの場合はfalseを返す" do
+      invitation = build(
+        :invitation,
+        status: :accepted,
+        expires_at: 1.day.from_now,
+        used_by: nil
+      )
+
+      expect(invitation.usable?).to eq(false)
+    end
+
+    it "used_byが設定されている場合はfalseを返す" do
+      used_user = create(:user)
+      invitation = build(
+        :invitation,
+        status: :pending,
+        expires_at: 1.day.from_now,
+        used_by: used_user
+      )
+
+      expect(invitation.usable?).to eq(false)
+    end
+  end
+end

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -1,0 +1,195 @@
+require "rails_helper"
+
+RSpec.describe "Invitations", type: :request do
+  describe "POST /groups/:group_id/invitations" do
+    context "ログインしている場合" do
+      it "招待を作成できる" do
+        user = create(:user)
+        group = create(:group)
+
+        create(
+          :group_membership,
+          user: user,
+          group: group,
+          role: :admin
+        )
+
+        post user_session_path, params: {
+          user: {
+            email: user.email,
+            password: "password123"
+          }
+        }
+
+        expect {
+          post group_invitations_path(group)
+        }.to change(Invitation, :count).by(1)
+
+        invitation = Invitation.last
+
+        expect(invitation.group).to eq(group)
+        expect(invitation.invited_by).to eq(user)
+        expect(response).to redirect_to(
+          share_invitation_path(invitation.token)
+        )
+      end
+    end
+  end
+
+  describe "POST /group_memberships/accept" do
+    context "有効な招待の場合" do
+      it "グループに参加できる" do
+        inviter = create(:user)
+        invitee = create(:user)
+        group = create(:group)
+
+        create(
+          :group_membership,
+          user: inviter,
+          group: group,
+          role: :admin
+        )
+
+        invitation = create(
+          :invitation,
+          group: group,
+          invited_by: inviter,
+          expires_at: 1.day.from_now,
+          status: :pending
+        )
+
+        get invitation_path(invitation.token)
+
+        post user_session_path, params: {
+          user: {
+            email: invitee.email,
+            password: "password123"
+          }
+        }
+
+        expect {
+          post accept_group_memberships_path
+        }.to change(GroupMembership, :count).by(1)
+
+        membership = GroupMembership.find_by(
+          user: invitee,
+          group: group
+        )
+
+        expect(membership).to be_present
+
+        invitation.reload
+
+        expect(invitation).to be_accepted
+        expect(invitation.used_by).to eq(invitee)
+        expect(invitation.accepted_at).to be_present
+      end
+    end
+
+    context "期限切れの招待の場合" do
+      it "招待URLを利用できない" do
+        inviter = create(:user)
+        group = create(:group)
+
+        invitation = create(
+          :invitation,
+          group: group,
+          invited_by: inviter,
+          expires_at: 1.day.ago,
+          status: :pending
+        )
+
+        get invitation_path(invitation.token)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "使用済みの招待の場合" do
+      it "招待URLを再利用できない" do
+        inviter = create(:user)
+        used_user = create(:user)
+        group = create(:group)
+
+        invitation = create(
+          :invitation,
+          group: group,
+          invited_by: inviter,
+          used_by: used_user,
+          status: :accepted,
+          expires_at: 1.day.from_now
+        )
+
+        get invitation_path(invitation.token)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "すでにグループに参加している場合" do
+      it "重複して参加しない" do
+        inviter = create(:user)
+        invitee = create(:user)
+        group = create(:group)
+
+        create(
+          :group_membership,
+          user: inviter,
+          group: group,
+          role: :admin
+        )
+
+        create(
+          :group_membership,
+          user: invitee,
+          group: group,
+          role: :member
+        )
+
+        invitation = create(
+          :invitation,
+          group: group,
+          invited_by: inviter,
+          expires_at: 1.day.from_now,
+          status: :pending
+        )
+
+        get invitation_path(invitation.token)
+
+        post user_session_path, params: {
+          user: {
+            email: invitee.email,
+            password: "password123"
+          }
+        }
+
+        expect {
+          post accept_group_memberships_path
+        }.not_to change(GroupMembership, :count)
+
+        expect(response).to redirect_to(group_path(group))
+      end
+    end
+
+    context "未ログインの場合" do
+      it "新規登録へ誘導される" do
+        inviter = create(:user)
+        group = create(:group)
+
+        invitation = create(
+          :invitation,
+          group: group,
+          invited_by: inviter,
+          expires_at: 1.day.from_now,
+          status: :pending
+        )
+
+        get invitation_path(invitation.token)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("参加する")
+        expect(response.body).to include(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
招待機能に対するModel Spec・Request Specを追加しました。

## 実装内容
### 1.Invitation Model Spec

- 有効なInvitationを作成できることを確認
- 招待ごとに異なるtokenが生成されることを確認
- expired? の期限内・期限切れの判定を確認
- usable? が以下の条件で正しく判定されることを確認
　- 未使用かつ有効期限内の場合
　- 有効期限切れの場合
　- accepted の場合
　- used_by が設定されている場合

### 2 .招待URL発行のRequest Spec

- ログインユーザーが所属グループの招待を作成できることを確認
- Invitationが対象のGroupに紐づくことを確認
- invited_by が招待を作成したユーザーになることを確認
- 招待作成後に招待共有画面へリダイレクトされることを確認

### 3 .招待からグループ参加するRequest Spec

- 有効期限内の招待URLからグループへ参加できることを確認
- 参加後にGroupMembershipが作成されることを確認
- Invitationのstatusがacceptedになることを確認
- used_byに参加ユーザーが設定されることを確認
- accepted_atが設定されることを確認

### 4 .招待の異常系

- 期限切れの招待URLは利用できないことを確認
- 使用済みの招待URLは再利用できないことを確認
- すでにグループ参加済みのユーザーは重複参加しないことを確認
- 参加済みの場合は既存のGroupMembershipが増えないことを確認
- 未ログインでも有効な招待ページを表示できることを確認
- 未ログイン時は「参加する」ボタンから新規登録へ誘導されることを確認

### 5.確認した内容

- 招待トークンが一意になる
- 有効期限内の招待URLから参加できる
- 期限切れの招待URLでは参加できない
- 使用済み招待URLでは再参加できない
- 既に参加済みのユーザーは重複参加しない
- 未ログイン時は新規登録へ誘導される

### 6 . 動作確認
- bundle exec rspec が正常に実行できることを確認

## 関連 Issue
Closes #176   